### PR TITLE
[Feat/#6] BaseTimeEntity 생성 및 엔티티 적용

### DIFF
--- a/src/main/java/com/swyp/server/domain/user/entity/User.java
+++ b/src/main/java/com/swyp/server/domain/user/entity/User.java
@@ -1,5 +1,7 @@
 package com.swyp.server.domain.user.entity;
 
+import com.swyp.server.global.BaseTimeEntity;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -17,7 +19,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "users")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class User {
+public class User extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/swyp/server/domain/user/entity/User.java
+++ b/src/main/java/com/swyp/server/domain/user/entity/User.java
@@ -1,6 +1,6 @@
 package com.swyp.server.domain.user.entity;
 
-import com.swyp.server.global.BaseTimeEntity;
+import com.swyp.server.global.SoftDeletableEntity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -19,7 +19,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "users")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class User extends BaseTimeEntity {
+public class User extends SoftDeletableEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/swyp/server/global/AuditableEntity.java
+++ b/src/main/java/com/swyp/server/global/AuditableEntity.java
@@ -14,10 +14,10 @@ import lombok.Getter;
 @Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
-public abstract class BaseTimeEntity {
+public abstract class AuditableEntity {
 
     @CreatedDate
-    @Column(updatable = false)
+    @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
     @LastModifiedDate private LocalDateTime updatedAt;

--- a/src/main/java/com/swyp/server/global/BaseTimeEntity.java
+++ b/src/main/java/com/swyp/server/global/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package com.swyp.server.global;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/swyp/server/global/SoftDeletableEntity.java
+++ b/src/main/java/com/swyp/server/global/SoftDeletableEntity.java
@@ -1,0 +1,21 @@
+package com.swyp.server.global;
+
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.SQLRestriction;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+@SQLRestriction("deleted_at IS NULL")
+public abstract class SoftDeletableEntity extends AuditableEntity {
+
+    @Column private LocalDateTime deletedAt;
+
+    public void delete() {
+        this.deletedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/swyp/server/global/config/JpaAuditingConfig.java
+++ b/src/main/java/com/swyp/server/global/config/JpaAuditingConfig.java
@@ -1,0 +1,8 @@
+package com.swyp.server.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {}

--- a/src/main/java/com/swyp/server/infra/fcm/FcmToken.java
+++ b/src/main/java/com/swyp/server/infra/fcm/FcmToken.java
@@ -1,6 +1,7 @@
 package com.swyp.server.infra.fcm;
 
 import com.swyp.server.domain.user.entity.User;
+import com.swyp.server.global.BaseTimeEntity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -20,7 +21,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "fcm_tokens")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class FcmToken {
+public class FcmToken extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/swyp/server/infra/fcm/FcmToken.java
+++ b/src/main/java/com/swyp/server/infra/fcm/FcmToken.java
@@ -1,7 +1,7 @@
 package com.swyp.server.infra.fcm;
 
 import com.swyp.server.domain.user.entity.User;
-import com.swyp.server.global.BaseTimeEntity;
+import com.swyp.server.global.AuditableEntity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -21,7 +21,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "fcm_tokens")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class FcmToken extends BaseTimeEntity {
+public class FcmToken extends AuditableEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
## 📌 관련 이슈
- close #6

## ✨ 변경 사항
- BaseTimeEntity 생성 (createdAt, updatedAt)
- JpaAuditingConfig 별도 분리 (@EnableJpaAuditing)
- User, FcmToken 엔티티에 BaseTimeEntity 적용

## 📸 테스트 증명 (필수)
로컬 빌드 성공 확인

## 📚 리뷰어 참고 사항
@EnableJpaAuditing을 ServerApplication에 달려다가,
테스트 시 JPA 빈 로딩 문제가 발생할 수 있어서
JpaAuditingConfig로 별도로 분리했습니다.

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요?
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?
- [x] spotlessApply 실행했나요?