### PR TITLE
[Fix/#15] Security permitAll URL v1 prefix 수정

### DIFF
--- a/src/main/java/com/swyp/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/swyp/server/global/config/SecurityConfig.java
@@ -18,7 +18,7 @@ public class SecurityConfig {
     private final JwtProvider jwtProvider;
 
     private static final String[] PUBLIC_URLS = {
-        "/api/auth/**", "/swagger-ui/**", "/api-docs/**", "/swagger-ui.html"
+        "/api/v1/auth/**", "/swagger-ui/**", "/api-docs/**", "/swagger-ui.html"
     };
 
     @Bean


### PR DESCRIPTION
## 📌 관련 이슈
- close #15

## ✨ 변경 사항
- Security permitAll URL /api/auth/** → /api/v1/auth/** 수정

## 📸 테스트 증명 (필수)
POST /api/v1/auth/login 호출 시 200 응답 확인
<img width="1230" height="300" alt="image" src="https://github.com/user-attachments/assets/9e66914a-1970-4d79-988d-bd65a9f69bf6" />


## 📚 리뷰어 참고 사항
- API URL v1 prefix 적용 시 Security 설정 누락된 부분 수정됐는지 확인

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요?
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?
- [x] spotlessApply 실행했나요?