### PR TITLE
[Fix/#20] CI/CD scp를 rsync로 변경

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,16 +25,15 @@ jobs:
         run: ./gradlew bootJar -x test
 
       - name: Copy jar to EC2
-        uses: appleboy/scp-action@master
-        with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ubuntu
-          key: ${{ secrets.EC2_SSH_KEY }}
-          source: "build/libs/server-0.0.1-SNAPSHOT.jar"
-          target: "~/app.jar"
-          strip_components: 3
+        run: |
+          echo "${{ secrets.EC2_SSH_KEY }}" > key.pem
+          chmod 600 key.pem
+          rsync -avz -e "ssh -i key.pem -o StrictHostKeyChecking=no" \
+            build/libs/server-0.0.1-SNAPSHOT.jar \
+            ubuntu@${{ secrets.EC2_HOST }}:/home/ubuntu/app.jar
+          rm -f key.pem
 
-      - name: Run application
+      - name: Restart application
         uses: appleboy/ssh-action@master
         with:
           host: ${{ secrets.EC2_HOST }}


### PR DESCRIPTION
## 📌 관련 이슈
- close #20

## ✨ 변경 사항
- scp-action → rsync 방식으로 변경 ( jar 전송 경로 문제 수정)

## 📸 테스트 증명 (필수)
PR 머지 후 Actions 탭에서 확인 예정

## 📚 리뷰어 참고 사항
- scp-action이 target 경로를 폴더로 인식하는 오류 발생
- rsync는 외부 액션 없이 직접 실행하여 더 안정적이라고 판단

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요?
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?
- [x] spotlessApply 실행했나요?