### PR TITLE
[Fix/#22] Jackson null 필드 제거하는 설정 삭제

### DIFF
--- a/src/main/java/com/swyp/server/global/response/ApiResponse.java
+++ b/src/main/java/com/swyp/server/global/response/ApiResponse.java
@@ -1,10 +1,8 @@
 package com.swyp.server.global.response;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Getter;
 
 @Getter
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ApiResponse<T> {
 
     private final int code;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,8 +3,6 @@ spring:
     import: optional:file:.env[.properties]
   application:
     name: server
-  jackson:
-    default-property-inclusion: non_null
 
   datasource:
     url: ${DB_URL}


### PR DESCRIPTION
## 📌 관련 이슈
- close #22

## ✨ 변경 사항
- ApiResponse @JsonInclude(NON_NULL) 제거
- application.yml jackson non_null 설정 제거

## 📸 테스트 증명 (필수)
변경 전 로그아웃 Response body: {"code":20000,"message":"요청이 성공했습니다."}
변경 후 로그아웃 Response body: {"code":20000,"message":"요청이 성공했습니다.","data":null}

## 📚 리뷰어 참고 사항
- 안드로이드 코틀린에서 data 필드 nullable 처리를 위해 수정
- 앞으로 data 없는 API도 data: null로 응답하도록 유의하겠습니다. (앱개발자 피드백 반영)

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요?
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?
- [x] spotlessApply 실행했나요?