### PR TITLE
[Feat/#26] GlobalExceptionHandler 및 Security 예외 처리 확장

### DIFF
--- a/src/main/java/com/swyp/server/domain/auth/dto/SocialLoginRequest.java
+++ b/src/main/java/com/swyp/server/domain/auth/dto/SocialLoginRequest.java
@@ -2,4 +2,6 @@ package com.swyp.server.domain.auth.dto;
 
 import jakarta.validation.constraints.NotBlank;
 
-public record SocialLoginRequest(@NotBlank String socialType, @NotBlank String token) {}
+public record SocialLoginRequest(
+        @NotBlank(message = "SOCIAL_TYPE_REQUIRED") String socialType,
+        @NotBlank(message = "SOCIAL_TOKEN_REQUIRED") String token) {}

--- a/src/main/java/com/swyp/server/domain/auth/service/GoogleAuthService.java
+++ b/src/main/java/com/swyp/server/domain/auth/service/GoogleAuthService.java
@@ -76,6 +76,7 @@ public class GoogleAuthService {
         // 만료 포함 모든 검증을 직접 처리
         Long userId;
         try {
+            jwtProvider.validateToken(token);
             userId = jwtProvider.getUserIdFromToken(token);
         } catch (CustomException e) {
             throw new CustomException(ErrorCode.INVALID_TOKEN);

--- a/src/main/java/com/swyp/server/global/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/swyp/server/global/config/JwtAuthenticationFilter.java
@@ -1,6 +1,7 @@
 package com.swyp.server.global.config;
 
 import com.swyp.server.global.exception.CustomException;
+import com.swyp.server.global.exception.JwtAuthenticationException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -36,6 +37,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             } catch (CustomException e) {
                 log.error("JWT authentication failed: {}", e.getMessage());
+                throw new JwtAuthenticationException(e.getErrorCode(), e);
             }
         }
 

--- a/src/main/java/com/swyp/server/global/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/swyp/server/global/config/JwtAuthenticationFilter.java
@@ -12,12 +12,14 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 @Slf4j
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private static final AntPathMatcher matcher = new AntPathMatcher();
 
     private final JwtProvider jwtProvider;
 
@@ -37,6 +39,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             } catch (CustomException e) {
                 log.error("JWT authentication failed: {}", e.getMessage());
+                SecurityContextHolder.clearContext();
                 throw new JwtAuthenticationException(e.getErrorCode(), e);
             }
         }
@@ -50,5 +53,17 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             return bearerToken.substring(7);
         }
         return null;
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        String uri = request.getRequestURI();
+
+        for (String publicUrl : SecurityPath.PUBLIC_URLS) {
+            if (matcher.match(publicUrl, uri)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/com/swyp/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/swyp/server/global/config/SecurityConfig.java
@@ -9,7 +9,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.authentication.AuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
@@ -19,10 +19,6 @@ public class SecurityConfig {
     private final JwtProvider jwtProvider;
     private final SecurityExceptionHandler securityExceptionHandler;
 
-    private static final String[] PUBLIC_URLS = {
-        "/api/v1/auth/**", "/swagger-ui/**", "/api-docs/**", "/swagger-ui.html"
-    };
-
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http.csrf(AbstractHttpConfigurer::disable)
@@ -30,13 +26,12 @@ public class SecurityConfig {
                         session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(
                         auth ->
-                                auth.requestMatchers(PUBLIC_URLS)
+                                auth.requestMatchers(SecurityPath.PUBLIC_URLS)
                                         .permitAll()
                                         .anyRequest()
                                         .authenticated())
                 .addFilterBefore(
-                        new JwtAuthenticationFilter(jwtProvider),
-                        UsernamePasswordAuthenticationFilter.class)
+                        new JwtAuthenticationFilter(jwtProvider), AuthenticationFilter.class)
                 .exceptionHandling(
                         ex ->
                                 ex.authenticationEntryPoint(securityExceptionHandler)

--- a/src/main/java/com/swyp/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/swyp/server/global/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.swyp.server.global.config;
 
+import com.swyp.server.global.exception.SecurityExceptionHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -16,6 +17,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final JwtProvider jwtProvider;
+    private final SecurityExceptionHandler securityExceptionHandler;
 
     private static final String[] PUBLIC_URLS = {
         "/api/v1/auth/**", "/swagger-ui/**", "/api-docs/**", "/swagger-ui.html"
@@ -34,7 +36,11 @@ public class SecurityConfig {
                                         .authenticated())
                 .addFilterBefore(
                         new JwtAuthenticationFilter(jwtProvider),
-                        UsernamePasswordAuthenticationFilter.class);
+                        UsernamePasswordAuthenticationFilter.class)
+                .exceptionHandling(
+                        ex ->
+                                ex.authenticationEntryPoint(securityExceptionHandler)
+                                        .accessDeniedHandler(securityExceptionHandler));
 
         return http.build();
     }

--- a/src/main/java/com/swyp/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/swyp/server/global/config/SecurityConfig.java
@@ -26,7 +26,8 @@ public class SecurityConfig {
                         session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(
                         auth ->
-                                auth.requestMatchers(SecurityPath.PUBLIC_URLS)
+                                auth.requestMatchers(
+                                                SecurityPath.PUBLIC_URLS.toArray(String[]::new))
                                         .permitAll()
                                         .anyRequest()
                                         .authenticated())

--- a/src/main/java/com/swyp/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/swyp/server/global/config/SecurityConfig.java
@@ -9,6 +9,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.intercept.AuthorizationFilter;
 import org.springframework.security.web.authentication.AuthenticationFilter;
 
 @Configuration
@@ -32,7 +33,7 @@ public class SecurityConfig {
                                         .anyRequest()
                                         .authenticated())
                 .addFilterBefore(
-                        new JwtAuthenticationFilter(jwtProvider), AuthenticationFilter.class)
+                        new JwtAuthenticationFilter(jwtProvider), AuthorizationFilter.class)
                 .exceptionHandling(
                         ex ->
                                 ex.authenticationEntryPoint(securityExceptionHandler)

--- a/src/main/java/com/swyp/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/swyp/server/global/config/SecurityConfig.java
@@ -10,7 +10,6 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.intercept.AuthorizationFilter;
-import org.springframework.security.web.authentication.AuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity

--- a/src/main/java/com/swyp/server/global/config/SecurityPath.java
+++ b/src/main/java/com/swyp/server/global/config/SecurityPath.java
@@ -1,12 +1,12 @@
 package com.swyp.server.global.config;
 
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class SecurityPath {
 
-    public static final String[] PUBLIC_URLS = {
-        "/api/v1/auth/**", "/swagger-ui/**", "/api-docs/**", "/swagger-ui.html"
-    };
+    public static final List<String> PUBLIC_URLS =
+            List.of("/api/v1/auth/**", "/swagger-ui/**", "/api-docs/**", "/swagger-ui.html");
 }

--- a/src/main/java/com/swyp/server/global/config/SecurityPath.java
+++ b/src/main/java/com/swyp/server/global/config/SecurityPath.java
@@ -1,0 +1,12 @@
+package com.swyp.server.global.config;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class SecurityPath {
+
+    public static final String[] PUBLIC_URLS = {
+        "/api/v1/auth/**", "/swagger-ui/**", "/api-docs/**", "/swagger-ui.html"
+    };
+}

--- a/src/main/java/com/swyp/server/global/exception/ErrorCode.java
+++ b/src/main/java/com/swyp/server/global/exception/ErrorCode.java
@@ -25,9 +25,29 @@ public enum ErrorCode {
     // FCM
     FCM_SEND_FAILED(50001, 500, "푸시 알림 전송에 실패했습니다."),
     FCM_TOPIC_SUBSCRIBE_FAILED(50002, 500, "푸시 토픽 구독에 실패했습니다."),
-    FCM_TOPIC_UNSUBSCRIBE_FAILED(50003, 500, "푸시 알림 구독 해제에 실패했습니다.");
+    FCM_TOPIC_UNSUBSCRIBE_FAILED(50003, 500, "푸시 알림 구독 해제에 실패했습니다."),
+
+    // Validation
+    FCM_TOKEN_REQUIRED(40001, 400, "FCM 토큰은 필수입니다."),
+    PLATFORM_REQUIRED(40002, 400, "플랫폼은 필수입니다."),
+
+    SOCIAL_TYPE_REQUIRED(40003, 400, "소셜 타입은 필수입니다."),
+    SOCIAL_TOKEN_REQUIRED(40004, 400, "소셜 토큰은 필수입니다.");
 
     private final int code;
     private final int status;
     private final String message;
+
+    // Validation annotation message에 설정한 key를 ErrorCode로 변환
+    public static ErrorCode fromValidationKey(String key) {
+        if (key == null || key.isBlank()) {
+            return INVALID_INPUT_VALUE;
+        }
+
+        try {
+            return ErrorCode.valueOf(key.trim());
+        } catch (IllegalArgumentException e) {
+            return INVALID_INPUT_VALUE;
+        }
+    }
 }

--- a/src/main/java/com/swyp/server/global/exception/ErrorCode.java
+++ b/src/main/java/com/swyp/server/global/exception/ErrorCode.java
@@ -8,24 +8,26 @@ import lombok.RequiredArgsConstructor;
 public enum ErrorCode {
 
     // Common
-    INVALID_INPUT_VALUE(40000, "입력값이 올바르지 않습니다."),
-    INTERNAL_SERVER_ERROR(50000, "서버 오류가 발생했습니다."),
+    INVALID_INPUT_VALUE(40000, 400, "입력값이 올바르지 않습니다."),
+    INTERNAL_SERVER_ERROR(50000, 500, "서버 오류가 발생했습니다."),
+    DATA_INTEGRITY_VIOLATION(40900, 409, "요청을 처리할 수 없습니다."),
 
     // Auth
-    UNAUTHORIZED(40100, "인증이 필요합니다."),
-    INVALID_TOKEN(40101, "유효하지 않은 토큰입니다."),
-    EXPIRED_TOKEN(40102, "만료된 토큰입니다."),
-    FORBIDDEN(40300, "접근 권한이 없습니다."),
+    UNAUTHORIZED(40100, 401, "인증이 필요합니다."),
+    INVALID_TOKEN(40101, 401, "유효하지 않은 토큰입니다."),
+    EXPIRED_TOKEN(40102, 401, "만료된 토큰입니다."),
+    FORBIDDEN(40300, 403, "접근 권한이 없습니다."),
 
     // User
-    USER_NOT_FOUND(40400, "사용자를 찾을 수 없습니다."),
-    DUPLICATE_EMAIL(40900, "이미 사용 중인 이메일입니다."),
+    USER_NOT_FOUND(40400, 404, "사용자를 찾을 수 없습니다."),
+    DUPLICATE_EMAIL(40900, 409, "이미 사용 중인 이메일입니다."),
 
     // FCM
-    FCM_SEND_FAILED(50001, "푸시 알림 전송에 실패했습니다."),
-    FCM_TOPIC_SUBSCRIBE_FAILED(50002, "푸시 토픽 구독에 실패했습니다."),
-    FCM_TOPIC_UNSUBSCRIBE_FAILED(50003, "푸시 알림 구독 해제에 실패했습니다.");
+    FCM_SEND_FAILED(50001, 500, "푸시 알림 전송에 실패했습니다."),
+    FCM_TOPIC_SUBSCRIBE_FAILED(50002, 500, "푸시 토픽 구독에 실패했습니다."),
+    FCM_TOPIC_UNSUBSCRIBE_FAILED(50003, 500, "푸시 알림 구독 해제에 실패했습니다.");
 
     private final int code;
+    private final int status;
     private final String message;
 }

--- a/src/main/java/com/swyp/server/global/exception/ErrorCode.java
+++ b/src/main/java/com/swyp/server/global/exception/ErrorCode.java
@@ -19,8 +19,8 @@ public enum ErrorCode {
     FORBIDDEN(40300, 403, "접근 권한이 없습니다."),
 
     // User
-    USER_NOT_FOUND(40400, 404, "사용자를 찾을 수 없습니다."),
-    DUPLICATE_EMAIL(40900, 409, "이미 사용 중인 이메일입니다."),
+    USER_NOT_FOUND(40401, 404, "사용자를 찾을 수 없습니다."),
+    DUPLICATE_EMAIL(40901, 409, "이미 사용 중인 이메일입니다."),
 
     // FCM
     FCM_SEND_FAILED(50001, 500, "푸시 알림 전송에 실패했습니다."),

--- a/src/main/java/com/swyp/server/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/swyp/server/global/exception/GlobalExceptionHandler.java
@@ -1,15 +1,21 @@
 package com.swyp.server.global.exception;
 
+import static com.swyp.server.global.exception.ErrorCode.DATA_INTEGRITY_VIOLATION;
 import static com.swyp.server.global.exception.ErrorCode.INTERNAL_SERVER_ERROR;
 import static com.swyp.server.global.exception.ErrorCode.INVALID_INPUT_VALUE;
 
 import com.swyp.server.global.response.ApiResponse;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @Slf4j
 @RestControllerAdvice
@@ -34,6 +40,52 @@ public class GlobalExceptionHandler {
                         .orElse(INVALID_INPUT_VALUE.getMessage());
         return ResponseEntity.status(INVALID_INPUT_VALUE.getStatus())
                 .body(ApiResponse.fail(INVALID_INPUT_VALUE.getCode(), message));
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ApiResponse<Void>> handleConstraintViolationException(
+            ConstraintViolationException e) {
+        // 우선순위 높은 에러 하나만 반환
+        String message =
+                e.getConstraintViolations().stream()
+                        .findFirst()
+                        .map(ConstraintViolation::getMessage)
+                        .orElse(INVALID_INPUT_VALUE.getMessage());
+
+        return ResponseEntity.status(INVALID_INPUT_VALUE.getStatus())
+                .body(ApiResponse.fail(INVALID_INPUT_VALUE.getCode(), message));
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ApiResponse<Void>> handleTypeMismatchException(
+            MethodArgumentTypeMismatchException e) {
+        return ResponseEntity.status(INVALID_INPUT_VALUE.getStatus())
+                .body(
+                        ApiResponse.fail(
+                                INVALID_INPUT_VALUE.getCode(), INVALID_INPUT_VALUE.getMessage()));
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiResponse<Void>> handleNotReadableException(
+            HttpMessageNotReadableException e) {
+        log.warn("HttpMessageNotReadableException", e);
+
+        return ResponseEntity.status(INVALID_INPUT_VALUE.getStatus())
+                .body(
+                        ApiResponse.fail(
+                                INVALID_INPUT_VALUE.getCode(), INVALID_INPUT_VALUE.getMessage()));
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<ApiResponse<Void>> handleIntegrityViolationException(
+            DataIntegrityViolationException e) {
+        log.warn("DataIntegrityViolationException", e);
+
+        return ResponseEntity.status(DATA_INTEGRITY_VIOLATION.getStatus())
+                .body(
+                        ApiResponse.fail(
+                                DATA_INTEGRITY_VIOLATION.getCode(),
+                                DATA_INTEGRITY_VIOLATION.getMessage()));
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/swyp/server/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/swyp/server/global/exception/GlobalExceptionHandler.java
@@ -8,10 +8,10 @@ import com.swyp.server.global.response.ApiResponse;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -33,27 +33,34 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiResponse<Void>> handleValidationException(
             MethodArgumentNotValidException e) {
         // 우선순위 높은 에러 하나만 반환
-        String message =
-                e.getBindingResult().getFieldErrors().stream()
-                        .findFirst()
-                        .map(DefaultMessageSourceResolvable::getDefaultMessage)
-                        .orElse(INVALID_INPUT_VALUE.getMessage());
-        return ResponseEntity.status(INVALID_INPUT_VALUE.getStatus())
-                .body(ApiResponse.fail(INVALID_INPUT_VALUE.getCode(), message));
+        FieldError fieldError =
+                e.getBindingResult().getFieldErrors().stream().findFirst().orElse(null);
+
+        ErrorCode errorCode = INVALID_INPUT_VALUE;
+
+        if (fieldError != null) {
+            errorCode = ErrorCode.fromValidationKey(fieldError.getDefaultMessage());
+        }
+
+        return ResponseEntity.status(errorCode.getStatus())
+                .body(ApiResponse.fail(errorCode.getCode(), errorCode.getMessage()));
     }
 
     @ExceptionHandler(ConstraintViolationException.class)
     public ResponseEntity<ApiResponse<Void>> handleConstraintViolationException(
             ConstraintViolationException e) {
         // 우선순위 높은 에러 하나만 반환
-        String message =
-                e.getConstraintViolations().stream()
-                        .findFirst()
-                        .map(ConstraintViolation::getMessage)
-                        .orElse(INVALID_INPUT_VALUE.getMessage());
+        ConstraintViolation<?> constraintViolation =
+                e.getConstraintViolations().stream().findFirst().orElse(null);
 
-        return ResponseEntity.status(INVALID_INPUT_VALUE.getStatus())
-                .body(ApiResponse.fail(INVALID_INPUT_VALUE.getCode(), message));
+        ErrorCode errorCode = INVALID_INPUT_VALUE;
+
+        if (constraintViolation != null) {
+            errorCode = ErrorCode.fromValidationKey(constraintViolation.getMessage());
+        }
+
+        return ResponseEntity.status(errorCode.getStatus())
+                .body(ApiResponse.fail(errorCode.getCode(), errorCode.getMessage()));
     }
 
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)

--- a/src/main/java/com/swyp/server/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/swyp/server/global/exception/GlobalExceptionHandler.java
@@ -1,7 +1,11 @@
 package com.swyp.server.global.exception;
 
+import static com.swyp.server.global.exception.ErrorCode.INTERNAL_SERVER_ERROR;
+import static com.swyp.server.global.exception.ErrorCode.INVALID_INPUT_VALUE;
+
 import com.swyp.server.global.response.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -13,9 +17,9 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<ApiResponse<Void>> handleCustomException(CustomException e) {
-        log.error("CustomException: {}", e.getMessage());
+        log.info("CustomException: {}", e.getErrorCode().getCode());
         ErrorCode errorCode = e.getErrorCode();
-        return ResponseEntity.status(errorCode.getCode() / 100)
+        return ResponseEntity.status(errorCode.getStatus())
                 .body(ApiResponse.fail(errorCode.getCode(), errorCode.getMessage()));
     }
 
@@ -26,19 +30,20 @@ public class GlobalExceptionHandler {
         String message =
                 e.getBindingResult().getFieldErrors().stream()
                         .findFirst()
-                        .map(fieldError -> fieldError.getDefaultMessage())
-                        .orElse("입력값이 올바르지 않습니다.");
-        return ResponseEntity.status(400)
-                .body(ApiResponse.fail(ErrorCode.INVALID_INPUT_VALUE.getCode(), message));
+                        .map(DefaultMessageSourceResolvable::getDefaultMessage)
+                        .orElse(INVALID_INPUT_VALUE.getMessage());
+        return ResponseEntity.status(INVALID_INPUT_VALUE.getStatus())
+                .body(ApiResponse.fail(INVALID_INPUT_VALUE.getCode(), message));
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
-        log.error("Exception: {}", e.getMessage());
-        return ResponseEntity.status(500)
+
+        log.error("Unhandled Exception", e);
+        return ResponseEntity.status(INTERNAL_SERVER_ERROR.getStatus())
                 .body(
                         ApiResponse.fail(
-                                ErrorCode.INTERNAL_SERVER_ERROR.getCode(),
-                                ErrorCode.INTERNAL_SERVER_ERROR.getMessage()));
+                                INTERNAL_SERVER_ERROR.getCode(),
+                                INTERNAL_SERVER_ERROR.getMessage()));
     }
 }

--- a/src/main/java/com/swyp/server/global/exception/JwtAuthenticationException.java
+++ b/src/main/java/com/swyp/server/global/exception/JwtAuthenticationException.java
@@ -1,0 +1,25 @@
+package com.swyp.server.global.exception;
+
+import lombok.Getter;
+import org.springframework.security.core.AuthenticationException;
+
+@Getter
+public class JwtAuthenticationException extends AuthenticationException {
+
+    private final ErrorCode errorCode;
+
+    public JwtAuthenticationException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public JwtAuthenticationException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public JwtAuthenticationException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode.getMessage(), cause);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/swyp/server/global/exception/SecurityExceptionHandler.java
+++ b/src/main/java/com/swyp/server/global/exception/SecurityExceptionHandler.java
@@ -31,6 +31,15 @@ public class SecurityExceptionHandler implements AuthenticationEntryPoint, Acces
             AuthenticationException authException)
             throws IOException, ServletException {
 
+        if (authException instanceof JwtAuthenticationException jwtEx) {
+            ErrorCode errorCode = jwtEx.getErrorCode();
+            write(
+                    response,
+                    errorCode.getStatus(),
+                    ApiResponse.fail(errorCode.getCode(), errorCode.getMessage()));
+            return;
+        }
+
         write(
                 response,
                 UNAUTHORIZED.getStatus(),

--- a/src/main/java/com/swyp/server/global/exception/SecurityExceptionHandler.java
+++ b/src/main/java/com/swyp/server/global/exception/SecurityExceptionHandler.java
@@ -1,0 +1,61 @@
+package com.swyp.server.global.exception;
+
+import static com.swyp.server.global.exception.ErrorCode.FORBIDDEN;
+import static com.swyp.server.global.exception.ErrorCode.UNAUTHORIZED;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.swyp.server.global.response.ApiResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SecurityExceptionHandler implements AuthenticationEntryPoint, AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException)
+            throws IOException, ServletException {
+
+        write(
+                response,
+                UNAUTHORIZED.getStatus(),
+                ApiResponse.fail(UNAUTHORIZED.getCode(), UNAUTHORIZED.getMessage()));
+    }
+
+    @Override
+    public void handle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AccessDeniedException accessDeniedException)
+            throws IOException, ServletException {
+
+        write(
+                response,
+                FORBIDDEN.getStatus(),
+                ApiResponse.fail(FORBIDDEN.getCode(), FORBIDDEN.getMessage()));
+    }
+
+    private void write(HttpServletResponse response, int httpStatus, ApiResponse<Void> body)
+            throws IOException {
+        response.setStatus(httpStatus);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+
+        objectMapper.writeValue(response.getWriter(), body);
+    }
+}

--- a/src/main/java/com/swyp/server/infra/fcm/dto/FcmTokenRegisterRequest.java
+++ b/src/main/java/com/swyp/server/infra/fcm/dto/FcmTokenRegisterRequest.java
@@ -5,5 +5,5 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record FcmTokenRegisterRequest(
-        @NotBlank(message = "FCM 토큰은 필수입니다.") String token,
-        @NotNull(message = "플랫폼은 필수입니다.") Platform platform) {}
+        @NotBlank(message = "FCM_TOKEN_REQUIRED") String token,
+        @NotNull(message = "PLATFORM_REQUIRED") Platform platform) {}


### PR DESCRIPTION
## 📌 관련 이슈
- close #26 

## ✨ 변경 사항
- GlobalExceptionHandler 예외 처리 확장
- Spring Security 인증/인가 실패 응답 형식 통일
- JWT 인증 실패 분기 처리
- 재발급 시 JWT 유효성 검증 추가

## 📸 테스트 증명 
- 권한 없는 API 호출
<img width="612" height="498" alt="스크린샷 2026-03-04 오전 10 35 58" src="https://github.com/user-attachments/assets/822655fa-1797-4ca5-aa19-54dbf2ba7767" />

- 잘못된 JSON 요청
<img width="648" height="481" alt="스크린샷 2026-03-04 오전 10 37 43" src="https://github.com/user-attachments/assets/7cde991c-dc46-43f8-bfa9-6d8b97d411ab" />

## 📚 리뷰어 참고 사항
- 예외 응답 포맷 관련해서 통일했습니다.
- reissue 하는 과정에서 `getUserIdFromToken()` 이 만료된 토큰이여도 userId를 반환하는 문제가  있는 것 같아  `validateToken()` 검증을 추가했습니다.
- 인증 흐름 관련해서 확인해주시면 감사하겠습니다.

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요?
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?
- [x] spotlessApply 실행했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized security exception handling for auth failures.
  * Public endpoints are excluded from security filtering for smoother unauthenticated access.

* **Bug Fixes**
  * JWT tokens are explicitly validated before processing to avoid invalid-token usage.
  * Error responses standardized to include explicit HTTP status codes.
  * Added handling for data integrity violations and expanded validation error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->