### PR TITLE
[Feat/#31] 로그인 이후 프로필 온보딩 구현

### DIFF
--- a/src/main/java/com/swyp/server/domain/auth/dto/LoginResponse.java
+++ b/src/main/java/com/swyp/server/domain/auth/dto/LoginResponse.java
@@ -1,3 +1,6 @@
 package com.swyp.server.domain.auth.dto;
 
-public record LoginResponse(String accessToken, String refreshToken, boolean profileCompleted) {}
+import com.swyp.server.domain.user.entity.UserType;
+
+public record LoginResponse(
+        String accessToken, String refreshToken, UserType userType, boolean profileCompleted) {}

--- a/src/main/java/com/swyp/server/domain/auth/dto/LoginResponse.java
+++ b/src/main/java/com/swyp/server/domain/auth/dto/LoginResponse.java
@@ -1,3 +1,3 @@
 package com.swyp.server.domain.auth.dto;
 
-public record LoginResponse(String accessToken, String refreshToken, boolean isNewUser) {}
+public record LoginResponse(String accessToken, String refreshToken, boolean profileCompleted) {}

--- a/src/main/java/com/swyp/server/domain/auth/service/GoogleAuthService.java
+++ b/src/main/java/com/swyp/server/domain/auth/service/GoogleAuthService.java
@@ -60,7 +60,8 @@ public class GoogleAuthService {
                                                 .token(refreshToken)
                                                 .build()));
 
-        return new LoginResponse(accessToken, refreshToken, user.isProfileCompleted());
+        return new LoginResponse(
+                accessToken, refreshToken, user.getUserType(), user.isProfileCompleted());
     }
 
     @Transactional
@@ -86,12 +87,15 @@ public class GoogleAuthService {
                 .findByToken(token)
                 .orElseThrow(() -> new CustomException(ErrorCode.INVALID_TOKEN));
 
+        User user = userService.findById(userId);
+
         String newAccessToken = jwtProvider.generateAccessToken(userId);
         String newRefreshToken = jwtProvider.generateRefreshToken(userId);
 
         refreshTokenRepository.findByUserId(userId).ifPresent(t -> t.updateToken(newRefreshToken));
 
-        return new LoginResponse(newAccessToken, newRefreshToken, false);
+        return new LoginResponse(
+                newAccessToken, newRefreshToken, user.getUserType(), user.isProfileCompleted());
     }
 
     private GoogleIdToken.Payload verifyGoogleToken(String idToken) {

--- a/src/main/java/com/swyp/server/domain/auth/service/GoogleAuthService.java
+++ b/src/main/java/com/swyp/server/domain/auth/service/GoogleAuthService.java
@@ -44,7 +44,6 @@ public class GoogleAuthService {
         String name = (String) payload.get("name");
         String pictureUrl = (String) payload.get("picture");
 
-        boolean isNewUser = !userService.existsByEmail(email);
         User user = userService.findOrCreateUser(email, name, pictureUrl);
 
         String accessToken = jwtProvider.generateAccessToken(user.getId());
@@ -61,7 +60,7 @@ public class GoogleAuthService {
                                                 .token(refreshToken)
                                                 .build()));
 
-        return new LoginResponse(accessToken, refreshToken, isNewUser);
+        return new LoginResponse(accessToken, refreshToken, user.isProfileCompleted());
     }
 
     @Transactional

--- a/src/main/java/com/swyp/server/domain/user/controller/UserController.java
+++ b/src/main/java/com/swyp/server/domain/user/controller/UserController.java
@@ -1,0 +1,31 @@
+package com.swyp.server.domain.user.controller;
+
+import com.swyp.server.domain.user.dto.ProfileRequest;
+import com.swyp.server.domain.user.service.UserService;
+import com.swyp.server.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "User", description = "유저 프로필 API")
+@RestController
+@RequestMapping("/api/v1/users/me")
+@RequiredArgsConstructor
+public class UserController {
+    private final UserService userService;
+
+    @Operation(summary = "내 프로필 설정")
+    @PatchMapping
+    public ResponseEntity<ApiResponse<Void>> updateProfile(
+            @AuthenticationPrincipal Long userId, @Valid @RequestBody ProfileRequest request) {
+        userService.updateProfile(userId, request.nickname(), request.userType());
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+}

--- a/src/main/java/com/swyp/server/domain/user/dto/ProfileRequest.java
+++ b/src/main/java/com/swyp/server/domain/user/dto/ProfileRequest.java
@@ -1,0 +1,14 @@
+package com.swyp.server.domain.user.dto;
+
+import com.swyp.server.domain.user.entity.UserType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record ProfileRequest(
+        @NotBlank(message = "NICKNAME_REQUIRED")
+                @Size(min = 1, max = 8, message = "NICKNAME_LENGTH_INVALID")
+                @Pattern(regexp = "^[a-zA-Z0-9가-힣]+$", message = "NICKNAME_PATTERN_INVALID")
+                String nickname,
+        @NotNull(message = "USER_TYPE_REQUIRED") UserType userType) {}

--- a/src/main/java/com/swyp/server/domain/user/entity/User.java
+++ b/src/main/java/com/swyp/server/domain/user/entity/User.java
@@ -27,8 +27,7 @@ public class User extends SoftDeletableEntity {
     @Column(nullable = false, unique = true)
     private String email;
 
-    @Column(nullable = false)
-    private String nickname;
+    @Column private String nickname;
 
     @Column private String profileImageUrl;
 
@@ -36,16 +35,33 @@ public class User extends SoftDeletableEntity {
     @Column(nullable = false)
     private Role role;
 
+    @Enumerated(EnumType.STRING)
+    private UserType userType;
+
+    @Enumerated(EnumType.STRING)
+    private WeekStartDay weekStartDay;
+
+    @Column(nullable = false)
+    private boolean profileCompleted;
+
     @Builder
     public User(String email, String nickname, String profileImageUrl, Role role) {
         this.email = email;
         this.nickname = nickname;
         this.profileImageUrl = profileImageUrl;
         this.role = role;
+        this.profileCompleted = false;
     }
 
     public void updateProfile(String nickname, String profileImageUrl) {
         this.nickname = nickname;
         this.profileImageUrl = profileImageUrl;
+    }
+
+    public void completeProfile(String nickname, UserType userType, WeekStartDay weekStartDay) {
+        this.nickname = nickname;
+        this.userType = userType;
+        this.weekStartDay = weekStartDay;
+        this.profileCompleted = true;
     }
 }

--- a/src/main/java/com/swyp/server/domain/user/entity/User.java
+++ b/src/main/java/com/swyp/server/domain/user/entity/User.java
@@ -38,9 +38,6 @@ public class User extends SoftDeletableEntity {
     @Enumerated(EnumType.STRING)
     private UserType userType;
 
-    @Enumerated(EnumType.STRING)
-    private WeekStartDay weekStartDay;
-
     @Column(nullable = false)
     private boolean profileCompleted;
 
@@ -58,10 +55,9 @@ public class User extends SoftDeletableEntity {
         this.profileImageUrl = profileImageUrl;
     }
 
-    public void completeProfile(String nickname, UserType userType, WeekStartDay weekStartDay) {
+    public void completeProfile(String nickname, UserType userType) {
         this.nickname = nickname;
         this.userType = userType;
-        this.weekStartDay = weekStartDay;
         this.profileCompleted = true;
     }
 }

--- a/src/main/java/com/swyp/server/domain/user/entity/UserType.java
+++ b/src/main/java/com/swyp/server/domain/user/entity/UserType.java
@@ -1,0 +1,6 @@
+package com.swyp.server.domain.user.entity;
+
+public enum UserType {
+    PARENT,
+    CHILD
+}

--- a/src/main/java/com/swyp/server/domain/user/entity/WeekStartDay.java
+++ b/src/main/java/com/swyp/server/domain/user/entity/WeekStartDay.java
@@ -1,0 +1,6 @@
+package com.swyp.server.domain.user.entity;
+
+public enum WeekStartDay {
+    SUNDAY,
+    MONDAY
+}

--- a/src/main/java/com/swyp/server/domain/user/entity/WeekStartDay.java
+++ b/src/main/java/com/swyp/server/domain/user/entity/WeekStartDay.java
@@ -1,6 +1,0 @@
-package com.swyp.server.domain.user.entity;
-
-public enum WeekStartDay {
-    SUNDAY,
-    MONDAY
-}

--- a/src/main/java/com/swyp/server/domain/user/service/UserService.java
+++ b/src/main/java/com/swyp/server/domain/user/service/UserService.java
@@ -2,7 +2,10 @@ package com.swyp.server.domain.user.service;
 
 import com.swyp.server.domain.user.entity.Role;
 import com.swyp.server.domain.user.entity.User;
+import com.swyp.server.domain.user.entity.UserType;
 import com.swyp.server.domain.user.repository.UserRepository;
+import com.swyp.server.global.exception.CustomException;
+import com.swyp.server.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,5 +34,22 @@ public class UserService {
     @Transactional(readOnly = true)
     public boolean existsByEmail(String email) {
         return userRepository.existsByEmail(email);
+    }
+
+    @Transactional(readOnly = true)
+    public User findById(Long userId) {
+        return userRepository
+                .findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    @Transactional
+    public void updateProfile(Long userId, String nickname, UserType userType) {
+        User user =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        user.completeProfile(nickname, userType);
     }
 }

--- a/src/main/java/com/swyp/server/global/exception/ErrorCode.java
+++ b/src/main/java/com/swyp/server/global/exception/ErrorCode.java
@@ -32,7 +32,12 @@ public enum ErrorCode {
     PLATFORM_REQUIRED(40002, 400, "플랫폼은 필수입니다."),
 
     SOCIAL_TYPE_REQUIRED(40003, 400, "소셜 타입은 필수입니다."),
-    SOCIAL_TOKEN_REQUIRED(40004, 400, "소셜 토큰은 필수입니다.");
+    SOCIAL_TOKEN_REQUIRED(40004, 400, "소셜 토큰은 필수입니다."),
+
+    NICKNAME_REQUIRED(40005, 400, "닉네임은 필수입니다."),
+    NICKNAME_LENGTH_INVALID(40006, 400, "닉네임은 1자 이상 8자 이하여야 합니다."),
+    NICKNAME_PATTERN_INVALID(40007, 400, "닉네임은 특수문자를 사용할 수 없습니다."),
+    USER_TYPE_REQUIRED(40008, 400, "사용자 유형은 필수입니다.");
 
     private final int code;
     private final int status;


### PR DESCRIPTION
## 📌 관련 이슈
- close #31 

## ✨ 변경 사항
- 로그인 시 신규 사용자를 미완성 상태로 저장하도록 수정
- 로그인 및 토큰 재발급 응답에 userType, profileCompleted 필드 추가
- 닉네임 입력값 검증 로직 추가
- User 엔티티에 ProfileCompleted 필드 추가
 
## 📸 테스트 증명 (필수)
<img width="515" height="527" alt="스크린샷 2026-03-09 오후 4 30 25" src="https://github.com/user-attachments/assets/410837eb-7c99-4819-84a9-fa7c9e834474" />

<img width="876" height="103" alt="스크린샷 2026-03-09 오후 4 30 58" src="https://github.com/user-attachments/assets/a3c40c33-db75-4ff7-ae12-37de7ae9c2e0" />


## 📚 리뷰어 참고 사항

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요?
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?
- [x] spotlessApply 실행했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now complete their profile by setting a nickname and selecting their user type (Parent or Child).
  * Login response now includes user type information and profile completion status.
  * Added input validation for profile information with character and length restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->