### PR TITLE
[Feat/#32] 회원탈퇴 API 구현

### DIFF
--- a/src/main/java/com/swyp/server/ServerApplication.java
+++ b/src/main/java/com/swyp/server/ServerApplication.java
@@ -2,7 +2,9 @@ package com.swyp.server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class ServerApplication {
 

--- a/src/main/java/com/swyp/server/domain/user/controller/UserController.java
+++ b/src/main/java/com/swyp/server/domain/user/controller/UserController.java
@@ -1,0 +1,28 @@
+package com.swyp.server.domain.user.controller;
+
+import com.swyp.server.domain.user.service.UserService;
+import com.swyp.server.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "User", description = "유저 API")
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @Operation(summary = "회원탈퇴")
+    @DeleteMapping("/me")
+    public ResponseEntity<ApiResponse<Void>> withdraw(@AuthenticationPrincipal Long userId) {
+        userService.withdraw(userId);
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+}

--- a/src/main/java/com/swyp/server/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/swyp/server/domain/user/repository/UserRepository.java
@@ -1,11 +1,20 @@
 package com.swyp.server.domain.user.repository;
 
 import com.swyp.server.domain.user.entity.User;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
 
     boolean existsByEmail(String email);
+
+    @Query(
+            value = "SELECT * FROM users WHERE deleted_at IS NOT NULL AND deleted_at <= :cutoff",
+            nativeQuery = true)
+    List<User> findAllDeletedBefore(@Param("cutoff") LocalDateTime cutoff);
 }

--- a/src/main/java/com/swyp/server/domain/user/service/UserService.java
+++ b/src/main/java/com/swyp/server/domain/user/service/UserService.java
@@ -1,8 +1,12 @@
 package com.swyp.server.domain.user.service;
 
+import com.swyp.server.domain.auth.repository.RefreshTokenRepository;
 import com.swyp.server.domain.user.entity.Role;
 import com.swyp.server.domain.user.entity.User;
 import com.swyp.server.domain.user.repository.UserRepository;
+import com.swyp.server.global.exception.CustomException;
+import com.swyp.server.global.exception.ErrorCode;
+import com.swyp.server.infra.fcm.repository.FcmTokenRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,6 +16,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final FcmTokenRepository fcmTokenRepository;
 
     @Transactional
     public User findOrCreateUser(String email, String nickname, String profileImageUrl) {
@@ -31,5 +37,16 @@ public class UserService {
     @Transactional(readOnly = true)
     public boolean existsByEmail(String email) {
         return userRepository.existsByEmail(email);
+    }
+
+    @Transactional
+    public void withdraw(Long userId) {
+        User user =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        refreshTokenRepository.deleteByUserId(userId);
+        fcmTokenRepository.deleteByUserId(userId);
+        user.delete();
     }
 }

--- a/src/main/java/com/swyp/server/domain/user/service/UserWithdrawalScheduler.java
+++ b/src/main/java/com/swyp/server/domain/user/service/UserWithdrawalScheduler.java
@@ -4,6 +4,7 @@ import com.swyp.server.domain.user.entity.User;
 import com.swyp.server.domain.user.repository.UserRepository;
 import com.swyp.server.infra.fcm.repository.FcmTokenRepository;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,7 +23,7 @@ public class UserWithdrawalScheduler {
     @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
     @Transactional
     public void hardDeleteWithdrawnUsers() {
-        LocalDateTime cutoff = LocalDateTime.now().minusDays(30);
+        LocalDateTime cutoff = LocalDateTime.now(ZoneId.of("Asia/Seoul")).minusDays(30);
         List<User> deletedUsers = userRepository.findAllDeletedBefore(cutoff);
 
         if (deletedUsers.isEmpty()) {

--- a/src/main/java/com/swyp/server/domain/user/service/UserWithdrawalScheduler.java
+++ b/src/main/java/com/swyp/server/domain/user/service/UserWithdrawalScheduler.java
@@ -1,0 +1,34 @@
+package com.swyp.server.domain.user.service;
+
+import com.swyp.server.domain.user.entity.User;
+import com.swyp.server.domain.user.repository.UserRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UserWithdrawalScheduler {
+
+    private final UserRepository userRepository;
+
+    // 매일 자정 실행
+    @Scheduled(cron = "0 0 0 * * *")
+    @Transactional
+    public void hardDeleteWithdrawnUsers() {
+        LocalDateTime cutoff = LocalDateTime.now().minusDays(30);
+        List<User> deletedUsers = userRepository.findAllDeletedBefore(cutoff);
+
+        if (deletedUsers.isEmpty()) {
+            return;
+        }
+
+        userRepository.deleteAll(deletedUsers);
+        log.info("Hard deleted {} withdrawn users", deletedUsers.size());
+    }
+}

--- a/src/main/java/com/swyp/server/domain/user/service/UserWithdrawalScheduler.java
+++ b/src/main/java/com/swyp/server/domain/user/service/UserWithdrawalScheduler.java
@@ -2,6 +2,7 @@ package com.swyp.server.domain.user.service;
 
 import com.swyp.server.domain.user.entity.User;
 import com.swyp.server.domain.user.repository.UserRepository;
+import com.swyp.server.infra.fcm.repository.FcmTokenRepository;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -16,9 +17,9 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserWithdrawalScheduler {
 
     private final UserRepository userRepository;
+    private final FcmTokenRepository fcmTokenRepository;
 
-    // 매일 자정 실행
-    @Scheduled(cron = "0 0 0 * * *")
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
     @Transactional
     public void hardDeleteWithdrawnUsers() {
         LocalDateTime cutoff = LocalDateTime.now().minusDays(30);
@@ -28,6 +29,7 @@ public class UserWithdrawalScheduler {
             return;
         }
 
+        deletedUsers.forEach(user -> fcmTokenRepository.deleteByUserId(user.getId()));
         userRepository.deleteAll(deletedUsers);
         log.info("Hard deleted {} withdrawn users", deletedUsers.size());
     }

--- a/src/main/java/com/swyp/server/global/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/swyp/server/global/config/JwtAuthenticationFilter.java
@@ -1,6 +1,8 @@
 package com.swyp.server.global.config;
 
+import com.swyp.server.domain.user.repository.UserRepository;
 import com.swyp.server.global.exception.CustomException;
+import com.swyp.server.global.exception.ErrorCode;
 import com.swyp.server.global.exception.JwtAuthenticationException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -22,6 +24,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private static final AntPathMatcher matcher = new AntPathMatcher();
 
     private final JwtProvider jwtProvider;
+    private final UserRepository userRepository;
 
     @Override
     protected void doFilterInternal(
@@ -33,6 +36,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             try {
                 jwtProvider.validateToken(token);
                 Long userId = jwtProvider.getUserIdFromToken(token);
+
+                // 탈퇴한 유저의 토큰 접근차단
+                if (!userRepository.existsById(userId)) {
+                    throw new CustomException(ErrorCode.USER_NOT_FOUND);
+                }
+
                 UsernamePasswordAuthenticationToken authentication =
                         new UsernamePasswordAuthenticationToken(
                                 userId, null, Collections.emptyList());

--- a/src/main/java/com/swyp/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/swyp/server/global/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.swyp.server.global.config;
 
+import com.swyp.server.domain.user.repository.UserRepository;
 import com.swyp.server.global.exception.SecurityExceptionHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -18,6 +19,7 @@ public class SecurityConfig {
 
     private final JwtProvider jwtProvider;
     private final SecurityExceptionHandler securityExceptionHandler;
+    private final UserRepository userRepository;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -32,7 +34,8 @@ public class SecurityConfig {
                                         .anyRequest()
                                         .authenticated())
                 .addFilterBefore(
-                        new JwtAuthenticationFilter(jwtProvider), AuthorizationFilter.class)
+                        new JwtAuthenticationFilter(jwtProvider, userRepository),
+                        AuthorizationFilter.class)
                 .exceptionHandling(
                         ex ->
                                 ex.authenticationEntryPoint(securityExceptionHandler)

--- a/src/main/java/com/swyp/server/infra/fcm/repository/FcmTokenRepository.java
+++ b/src/main/java/com/swyp/server/infra/fcm/repository/FcmTokenRepository.java
@@ -13,4 +13,6 @@ public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
     void deleteByUserIdAndToken(Long userId, String token);
 
     void deleteByToken(String token);
+
+    void deleteByUserId(Long userId);
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #32

## ✨ 변경 사항
- DELETE /api/v1/users/me 회원탈퇴 API 구현
- 탈퇴 시 RefreshToken 삭제
- 탈퇴 시 FCM 토큰 전체 삭제
- Soft Delete 방식으로 처리
- 30일 후 실제데이터 삭제 스케줄러 추가함 (@Scheduled 매일 자정 실행)

## 📸 테스트 증명 (필수)
로컬에서 Swagger로 테스트예정

## 📚 리뷰어 참고 사항
- SoftDeletableEntity의 delete() 메서드로 deletedAt 설정
- @SQLRestriction으로 삭제된 유저 자동 필터링

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요?
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?
- [x] spotlessApply 실행했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Account withdrawal endpoint: users can delete their account; sessions and registered devices are removed immediately.
  * Automatic cleanup: withdrawn accounts are permanently removed after a 30-day retention by a nightly scheduled job.
  * Scheduling enabled to support background cleanup.

* **Bug Fixes**
  * Requests using tokens for deleted/nonexistent users are rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->