### PR TITLE
[Feat/#34] Todo 기능 구현

### DIFF
--- a/src/main/java/com/swyp/server/domain/todo/controller/TodoController.java
+++ b/src/main/java/com/swyp/server/domain/todo/controller/TodoController.java
@@ -38,11 +38,11 @@ public class TodoController {
     @PostMapping
     public ResponseEntity<ApiResponse<TodoCreateResponse>> createTodo(
             @AuthenticationPrincipal Long userId, @Valid @RequestBody TodoCreateRequest request) {
-        Long todoId =
+        Todo todo =
                 todoService.createTodo(
                         userId, request.title(), request.category(), request.todoDate());
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(ApiResponse.created(new TodoCreateResponse(todoId)));
+                .body(ApiResponse.created(TodoCreateResponse.from(todo)));
     }
 
     @Operation(summary = "날짜별 할 일 조회")

--- a/src/main/java/com/swyp/server/domain/todo/controller/TodoController.java
+++ b/src/main/java/com/swyp/server/domain/todo/controller/TodoController.java
@@ -3,6 +3,7 @@ package com.swyp.server.domain.todo.controller;
 import com.swyp.server.domain.todo.dto.TodoCreateRequest;
 import com.swyp.server.domain.todo.dto.TodoCreateResponse;
 import com.swyp.server.domain.todo.dto.TodoListResponse;
+import com.swyp.server.domain.todo.dto.TodoUpdateRequest;
 import com.swyp.server.domain.todo.entity.Todo;
 import com.swyp.server.domain.todo.service.TodoService;
 import com.swyp.server.global.response.ApiResponse;
@@ -12,9 +13,12 @@ import jakarta.validation.Valid;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -36,15 +40,33 @@ public class TodoController {
         Long todoId =
                 todoService.createTodo(
                         userId, request.title(), request.category(), request.todoDate());
-        return ResponseEntity.ok(ApiResponse.created(new TodoCreateResponse(todoId)));
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.created(new TodoCreateResponse(todoId)));
     }
 
     @Operation(summary = "날짜별 할 일 조회")
     @GetMapping
     public ResponseEntity<ApiResponse<TodoListResponse>> getTodosByDate(
-            @AuthenticationPrincipal long userId, @RequestParam LocalDate date) {
+            @AuthenticationPrincipal Long userId, @RequestParam LocalDate date) {
 
         List<Todo> todos = todoService.getTodosByDate(userId, date);
         return ResponseEntity.ok(ApiResponse.success(TodoListResponse.from(todos)));
+    }
+
+    @Operation(summary = "할 일 수정")
+    @PatchMapping("/{todoId}")
+    public ResponseEntity<ApiResponse<Void>> updateTodo(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long todoId,
+            @Valid @RequestBody TodoUpdateRequest request) {
+
+        todoService.updateTodo(
+                userId,
+                todoId,
+                request.title(),
+                request.category(),
+                request.todoDate(),
+                request.completed());
+        return ResponseEntity.ok(ApiResponse.success(null));
     }
 }

--- a/src/main/java/com/swyp/server/domain/todo/controller/TodoController.java
+++ b/src/main/java/com/swyp/server/domain/todo/controller/TodoController.java
@@ -2,17 +2,23 @@ package com.swyp.server.domain.todo.controller;
 
 import com.swyp.server.domain.todo.dto.TodoCreateRequest;
 import com.swyp.server.domain.todo.dto.TodoCreateResponse;
+import com.swyp.server.domain.todo.dto.TodoListResponse;
+import com.swyp.server.domain.todo.entity.Todo;
 import com.swyp.server.domain.todo.service.TodoService;
 import com.swyp.server.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.time.LocalDate;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Todo", description = "할 일 API")
@@ -31,5 +37,14 @@ public class TodoController {
                 todoService.createTodo(
                         userId, request.title(), request.category(), request.todoDate());
         return ResponseEntity.ok(ApiResponse.created(new TodoCreateResponse(todoId)));
+    }
+
+    @Operation(summary = "날짜별 할 일 조회")
+    @GetMapping
+    public ResponseEntity<ApiResponse<TodoListResponse>> getTodosByDate(
+            @AuthenticationPrincipal long userId, @RequestParam LocalDate date) {
+
+        List<Todo> todos = todoService.getTodosByDate(userId, date);
+        return ResponseEntity.ok(ApiResponse.success(TodoListResponse.from(todos)));
     }
 }

--- a/src/main/java/com/swyp/server/domain/todo/controller/TodoController.java
+++ b/src/main/java/com/swyp/server/domain/todo/controller/TodoController.java
@@ -1,0 +1,35 @@
+package com.swyp.server.domain.todo.controller;
+
+import com.swyp.server.domain.todo.dto.TodoCreateRequest;
+import com.swyp.server.domain.todo.dto.TodoCreateResponse;
+import com.swyp.server.domain.todo.service.TodoService;
+import com.swyp.server.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Todo", description = "할 일 API")
+@RestController
+@RequestMapping("/api/v1/todos")
+@RequiredArgsConstructor
+public class TodoController {
+
+    private final TodoService todoService;
+
+    @Operation(summary = "할 일 생성")
+    @PostMapping
+    public ResponseEntity<ApiResponse<TodoCreateResponse>> createTodo(
+            @AuthenticationPrincipal Long userId, @Valid @RequestBody TodoCreateRequest request) {
+        Long todoId =
+                todoService.createTodo(
+                        userId, request.title(), request.category(), request.todoDate());
+        return ResponseEntity.ok(ApiResponse.created(new TodoCreateResponse(todoId)));
+    }
+}

--- a/src/main/java/com/swyp/server/domain/todo/controller/TodoController.java
+++ b/src/main/java/com/swyp/server/domain/todo/controller/TodoController.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -67,6 +68,15 @@ public class TodoController {
                 request.category(),
                 request.todoDate(),
                 request.completed());
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
+    @Operation(summary = "할 일 삭제")
+    @DeleteMapping("/{todoId}")
+    public ResponseEntity<ApiResponse<Void>> deleteTodo(
+            @AuthenticationPrincipal Long userId, @PathVariable Long todoId) {
+        todoService.deleteTodo(userId, todoId);
+
         return ResponseEntity.ok(ApiResponse.success(null));
     }
 }

--- a/src/main/java/com/swyp/server/domain/todo/controller/TodoController.java
+++ b/src/main/java/com/swyp/server/domain/todo/controller/TodoController.java
@@ -40,7 +40,11 @@ public class TodoController {
             @AuthenticationPrincipal Long userId, @Valid @RequestBody TodoCreateRequest request) {
         Todo todo =
                 todoService.createTodo(
-                        userId, request.title(), request.category(), request.todoDate());
+                        userId,
+                        request.title(),
+                        request.category(),
+                        request.color(),
+                        request.todoDate());
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.created(TodoCreateResponse.from(todo)));
     }
@@ -66,6 +70,7 @@ public class TodoController {
                 todoId,
                 request.title(),
                 request.category(),
+                request.color(),
                 request.todoDate(),
                 request.completed());
         return ResponseEntity.ok(ApiResponse.success(null));

--- a/src/main/java/com/swyp/server/domain/todo/dto/TodoCreateRequest.java
+++ b/src/main/java/com/swyp/server/domain/todo/dto/TodoCreateRequest.java
@@ -1,6 +1,7 @@
 package com.swyp.server.domain.todo.dto;
 
 import com.swyp.server.domain.todo.entity.TodoCategory;
+import com.swyp.server.domain.todo.entity.TodoColor;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -11,4 +12,5 @@ public record TodoCreateRequest(
                 @Size(max = 12, message = "TODO_TITLE_LENGTH_INVALID")
                 String title,
         @NotNull(message = "TODO_CATEGORY_REQUIRED") TodoCategory category,
+        @NotNull(message = "TODO_COLOR_REQUIRED") TodoColor color,
         @NotNull(message = "TODO_DATE_REQUIRED") LocalDate todoDate) {}

--- a/src/main/java/com/swyp/server/domain/todo/dto/TodoCreateRequest.java
+++ b/src/main/java/com/swyp/server/domain/todo/dto/TodoCreateRequest.java
@@ -8,7 +8,7 @@ import java.time.LocalDate;
 
 public record TodoCreateRequest(
         @NotBlank(message = "TODO_TITLE_REQUIRED")
-                @Size(max = 50, message = "TODO_TITLE_LENGTH_INVALID")
+                @Size(max = 12, message = "TODO_TITLE_LENGTH_INVALID")
                 String title,
         @NotNull(message = "TODO_CATEGORY_REQUIRED") TodoCategory category,
         @NotNull(message = "TODO_DATE_REQUIRED") LocalDate todoDate) {}

--- a/src/main/java/com/swyp/server/domain/todo/dto/TodoCreateRequest.java
+++ b/src/main/java/com/swyp/server/domain/todo/dto/TodoCreateRequest.java
@@ -10,5 +10,5 @@ public record TodoCreateRequest(
         @NotBlank(message = "TODO_TITLE_REQUIRED")
                 @Size(max = 50, message = "TODO_TITLE_LENGTH_INVALID")
                 String title,
-        @NotNull(message = "TODO_CATEGORY_CATEGORY_REQUIRED") TodoCategory category,
+        @NotNull(message = "TODO_CATEGORY_REQUIRED") TodoCategory category,
         @NotNull(message = "TODO_DATE_REQUIRED") LocalDate todoDate) {}

--- a/src/main/java/com/swyp/server/domain/todo/dto/TodoCreateRequest.java
+++ b/src/main/java/com/swyp/server/domain/todo/dto/TodoCreateRequest.java
@@ -1,8 +1,14 @@
 package com.swyp.server.domain.todo.dto;
 
 import com.swyp.server.domain.todo.entity.TodoCategory;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 
 public record TodoCreateRequest(
-        // todo validation 추가하기
-        String title, TodoCategory category, LocalDate todoDate) {}
+        @NotBlank(message = "TODO_TITLE_REQUIRED")
+                @Size(max = 50, message = "TODO_TITLE_LENGTH_INVALID")
+                String title,
+        @NotNull(message = "TODO_CATEGORY_CATEGORY_REQUIRED") TodoCategory category,
+        @NotNull(message = "TODO_DATE_REQUIRED") LocalDate todoDate) {}

--- a/src/main/java/com/swyp/server/domain/todo/dto/TodoCreateRequest.java
+++ b/src/main/java/com/swyp/server/domain/todo/dto/TodoCreateRequest.java
@@ -1,0 +1,8 @@
+package com.swyp.server.domain.todo.dto;
+
+import com.swyp.server.domain.todo.entity.TodoCategory;
+import java.time.LocalDate;
+
+public record TodoCreateRequest(
+        // todo validation 추가하기
+        String title, TodoCategory category, LocalDate todoDate) {}

--- a/src/main/java/com/swyp/server/domain/todo/dto/TodoCreateResponse.java
+++ b/src/main/java/com/swyp/server/domain/todo/dto/TodoCreateResponse.java
@@ -19,7 +19,7 @@ public record TodoCreateResponse(
                 todo.getTitle(),
                 todo.getCategory(),
                 todo.getTodoDate(),
-                todo.getCategory().getColor(),
+                todo.getColor(),
                 todo.isCompleted());
     }
 }

--- a/src/main/java/com/swyp/server/domain/todo/dto/TodoCreateResponse.java
+++ b/src/main/java/com/swyp/server/domain/todo/dto/TodoCreateResponse.java
@@ -1,0 +1,3 @@
+package com.swyp.server.domain.todo.dto;
+
+public record TodoCreateResponse(Long todoId) {}

--- a/src/main/java/com/swyp/server/domain/todo/dto/TodoCreateResponse.java
+++ b/src/main/java/com/swyp/server/domain/todo/dto/TodoCreateResponse.java
@@ -1,3 +1,25 @@
 package com.swyp.server.domain.todo.dto;
 
-public record TodoCreateResponse(Long todoId) {}
+import com.swyp.server.domain.todo.entity.Todo;
+import com.swyp.server.domain.todo.entity.TodoCategory;
+import com.swyp.server.domain.todo.entity.TodoColor;
+import java.time.LocalDate;
+
+public record TodoCreateResponse(
+        Long todoId,
+        String title,
+        TodoCategory category,
+        LocalDate todoDate,
+        TodoColor color,
+        boolean completed) {
+
+    public static TodoCreateResponse from(Todo todo) {
+        return new TodoCreateResponse(
+                todo.getId(),
+                todo.getTitle(),
+                todo.getCategory(),
+                todo.getTodoDate(),
+                todo.getCategory().getColor(),
+                todo.isCompleted());
+    }
+}

--- a/src/main/java/com/swyp/server/domain/todo/dto/TodoListResponse.java
+++ b/src/main/java/com/swyp/server/domain/todo/dto/TodoListResponse.java
@@ -3,9 +3,29 @@ package com.swyp.server.domain.todo.dto;
 import com.swyp.server.domain.todo.entity.Todo;
 import java.util.List;
 
-public record TodoListResponse(List<TodoResponse> todos) {
+public record TodoListResponse(
+        int totalCount,
+        int completedCount,
+        int remainingCount,
+        int progressPercent,
+        List<TodoResponse> todos) {
 
     public static TodoListResponse from(List<Todo> todos) {
-        return new TodoListResponse(todos.stream().map(TodoResponse::from).toList());
+
+        int total = todos.size();
+        int completed = (int) todos.stream().filter(Todo::isCompleted).count();
+        int remaining = total - completed;
+        int percent = 0;
+
+        if (total != 0) {
+            percent = (completed * 100) / total;
+        }
+
+        return new TodoListResponse(
+                total,
+                completed,
+                remaining,
+                percent,
+                todos.stream().map(TodoResponse::from).toList());
     }
 }

--- a/src/main/java/com/swyp/server/domain/todo/dto/TodoListResponse.java
+++ b/src/main/java/com/swyp/server/domain/todo/dto/TodoListResponse.java
@@ -1,0 +1,11 @@
+package com.swyp.server.domain.todo.dto;
+
+import com.swyp.server.domain.todo.entity.Todo;
+import java.util.List;
+
+public record TodoListResponse(List<TodoResponse> todos) {
+
+    public static TodoListResponse from(List<Todo> todos) {
+        return new TodoListResponse(todos.stream().map(TodoResponse::from).toList());
+    }
+}

--- a/src/main/java/com/swyp/server/domain/todo/dto/TodoResponse.java
+++ b/src/main/java/com/swyp/server/domain/todo/dto/TodoResponse.java
@@ -1,0 +1,11 @@
+package com.swyp.server.domain.todo.dto;
+
+import com.swyp.server.domain.todo.entity.Todo;
+import com.swyp.server.domain.todo.entity.TodoCategory;
+
+public record TodoResponse(Long todoId, String title, TodoCategory category, boolean completed) {
+    public static TodoResponse from(Todo todo) {
+        return new TodoResponse(
+                todo.getId(), todo.getTitle(), todo.getCategory(), todo.isCompleted());
+    }
+}

--- a/src/main/java/com/swyp/server/domain/todo/dto/TodoResponse.java
+++ b/src/main/java/com/swyp/server/domain/todo/dto/TodoResponse.java
@@ -2,10 +2,16 @@ package com.swyp.server.domain.todo.dto;
 
 import com.swyp.server.domain.todo.entity.Todo;
 import com.swyp.server.domain.todo.entity.TodoCategory;
+import com.swyp.server.domain.todo.entity.TodoColor;
 
-public record TodoResponse(Long todoId, String title, TodoCategory category, boolean completed) {
+public record TodoResponse(
+        Long todoId, String title, TodoCategory category, TodoColor color, boolean completed) {
     public static TodoResponse from(Todo todo) {
         return new TodoResponse(
-                todo.getId(), todo.getTitle(), todo.getCategory(), todo.isCompleted());
+                todo.getId(),
+                todo.getTitle(),
+                todo.getCategory(),
+                todo.getCategory().getColor(),
+                todo.isCompleted());
     }
 }

--- a/src/main/java/com/swyp/server/domain/todo/dto/TodoResponse.java
+++ b/src/main/java/com/swyp/server/domain/todo/dto/TodoResponse.java
@@ -11,7 +11,7 @@ public record TodoResponse(
                 todo.getId(),
                 todo.getTitle(),
                 todo.getCategory(),
-                todo.getCategory().getColor(),
+                todo.getColor(),
                 todo.isCompleted());
     }
 }

--- a/src/main/java/com/swyp/server/domain/todo/dto/TodoUpdateRequest.java
+++ b/src/main/java/com/swyp/server/domain/todo/dto/TodoUpdateRequest.java
@@ -1,6 +1,7 @@
 package com.swyp.server.domain.todo.dto;
 
 import com.swyp.server.domain.todo.entity.TodoCategory;
+import com.swyp.server.domain.todo.entity.TodoColor;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 
@@ -8,4 +9,5 @@ public record TodoUpdateRequest(
         @Size(max = 12, message = "TODO_TITLE_LENGTH_INVALID") String title,
         TodoCategory category,
         LocalDate todoDate,
+        TodoColor color,
         Boolean completed) {}

--- a/src/main/java/com/swyp/server/domain/todo/dto/TodoUpdateRequest.java
+++ b/src/main/java/com/swyp/server/domain/todo/dto/TodoUpdateRequest.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 
 public record TodoUpdateRequest(
-        @Size(max = 50, message = "TODO_TITLE_LENGTH_INVALID") String title,
+        @Size(max = 12, message = "TODO_TITLE_LENGTH_INVALID") String title,
         TodoCategory category,
         LocalDate todoDate,
         Boolean completed) {}

--- a/src/main/java/com/swyp/server/domain/todo/dto/TodoUpdateRequest.java
+++ b/src/main/java/com/swyp/server/domain/todo/dto/TodoUpdateRequest.java
@@ -1,8 +1,11 @@
 package com.swyp.server.domain.todo.dto;
 
 import com.swyp.server.domain.todo.entity.TodoCategory;
+import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 
 public record TodoUpdateRequest(
-        // todo validation 추가
-        String title, TodoCategory category, LocalDate todoDate, Boolean completed) {}
+        @Size(max = 50, message = "TODO_TITLE_LENGTH_INVALID") String title,
+        TodoCategory category,
+        LocalDate todoDate,
+        Boolean completed) {}

--- a/src/main/java/com/swyp/server/domain/todo/dto/TodoUpdateRequest.java
+++ b/src/main/java/com/swyp/server/domain/todo/dto/TodoUpdateRequest.java
@@ -1,0 +1,8 @@
+package com.swyp.server.domain.todo.dto;
+
+import com.swyp.server.domain.todo.entity.TodoCategory;
+import java.time.LocalDate;
+
+public record TodoUpdateRequest(
+        // todo validation 추가
+        String title, TodoCategory category, LocalDate todoDate, Boolean completed) {}

--- a/src/main/java/com/swyp/server/domain/todo/entity/Todo.java
+++ b/src/main/java/com/swyp/server/domain/todo/entity/Todo.java
@@ -35,7 +35,7 @@ public class Todo extends SoftDeletableEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @Column(nullable = false, length = 50)
+    @Column(nullable = false, length = 12)
     private String title;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/swyp/server/domain/todo/entity/Todo.java
+++ b/src/main/java/com/swyp/server/domain/todo/entity/Todo.java
@@ -55,9 +55,15 @@ public class Todo extends AuditableEntity {
         this.completed = false;
     }
 
-    public void update(String title, TodoCategory category, LocalDate todoDate) {
+    public void updateTitle(String title) {
         this.title = title;
+    }
+
+    public void updateCategory(TodoCategory category) {
         this.category = category;
+    }
+
+    public void updateTodoDate(LocalDate todoDate) {
         this.todoDate = todoDate;
     }
 

--- a/src/main/java/com/swyp/server/domain/todo/entity/Todo.java
+++ b/src/main/java/com/swyp/server/domain/todo/entity/Todo.java
@@ -1,7 +1,7 @@
 package com.swyp.server.domain.todo.entity;
 
 import com.swyp.server.domain.user.entity.User;
-import com.swyp.server.global.AuditableEntity;
+import com.swyp.server.global.SoftDeletableEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -23,7 +23,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "todos")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Todo extends AuditableEntity {
+public class Todo extends SoftDeletableEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/swyp/server/domain/todo/entity/Todo.java
+++ b/src/main/java/com/swyp/server/domain/todo/entity/Todo.java
@@ -18,11 +18,13 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Table(name = "todos")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("deleted_at IS NULL")
 public class Todo extends SoftDeletableEntity {
 
     @Id

--- a/src/main/java/com/swyp/server/domain/todo/entity/Todo.java
+++ b/src/main/java/com/swyp/server/domain/todo/entity/Todo.java
@@ -40,6 +40,10 @@ public class Todo extends SoftDeletableEntity {
     @Column(nullable = false)
     private TodoCategory category;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private TodoColor color;
+
     @Column(nullable = false)
     private LocalDate todoDate;
 
@@ -47,10 +51,12 @@ public class Todo extends SoftDeletableEntity {
     private boolean completed;
 
     @Builder
-    public Todo(User user, String title, TodoCategory category, LocalDate todoDate) {
+    public Todo(
+            User user, String title, TodoCategory category, TodoColor color, LocalDate todoDate) {
         this.user = user;
         this.title = title;
         this.category = category;
+        this.color = color;
         this.todoDate = todoDate;
         this.completed = false;
     }
@@ -61,6 +67,10 @@ public class Todo extends SoftDeletableEntity {
 
     public void updateCategory(TodoCategory category) {
         this.category = category;
+    }
+
+    public void updateColor(TodoColor color) {
+        this.color = color;
     }
 
     public void updateTodoDate(LocalDate todoDate) {

--- a/src/main/java/com/swyp/server/domain/todo/entity/Todo.java
+++ b/src/main/java/com/swyp/server/domain/todo/entity/Todo.java
@@ -1,0 +1,71 @@
+package com.swyp.server.domain.todo.entity;
+
+import com.swyp.server.domain.user.entity.User;
+import com.swyp.server.global.AuditableEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "todos")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Todo extends AuditableEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false, length = 50)
+    private String title;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private TodoCategory category;
+
+    @Column(nullable = false)
+    private LocalDate todoDate;
+
+    @Column(nullable = false)
+    private boolean completed;
+
+    @Builder
+    public Todo(User user, String title, TodoCategory category, LocalDate todoDate) {
+        this.user = user;
+        this.title = title;
+        this.category = category;
+        this.todoDate = todoDate;
+        this.completed = false;
+    }
+
+    public void update(String title, TodoCategory category, LocalDate todoDate) {
+        this.title = title;
+        this.category = category;
+        this.todoDate = todoDate;
+    }
+
+    public void complete() {
+        this.completed = true;
+    }
+
+    public void incomplete() {
+        this.completed = false;
+    }
+}

--- a/src/main/java/com/swyp/server/domain/todo/entity/TodoCategory.java
+++ b/src/main/java/com/swyp/server/domain/todo/entity/TodoCategory.java
@@ -4,10 +4,9 @@ public enum TodoCategory {
     STUDY,
     HOMEWORK,
     READING,
-    ACTIVITY,
-    CLEANING,
-    HELPING,
+    CREATIVITY,
     HEALTH,
-    MIND,
-    FOCUS
+    ORGANIZATION,
+    FOCUS,
+    HOUSEHOLD
 }

--- a/src/main/java/com/swyp/server/domain/todo/entity/TodoCategory.java
+++ b/src/main/java/com/swyp/server/domain/todo/entity/TodoCategory.java
@@ -1,12 +1,21 @@
 package com.swyp.server.domain.todo.entity;
 
+import static com.swyp.server.domain.todo.entity.TodoColor.*;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum TodoCategory {
-    STUDY,
-    HOMEWORK,
-    READING,
-    CREATIVITY,
-    HEALTH,
-    ORGANIZATION,
-    FOCUS,
-    HOUSEHOLD
+    STUDY(RED),
+    HOMEWORK(PINK),
+    READING(PURPLE),
+    CREATIVITY(BLUE),
+    HEALTH(SKYBLUE),
+    ORGANIZATION(MINT),
+    FOCUS(EMERALD),
+    HOUSEHOLD(LIME);
+
+    private final TodoColor color;
 }

--- a/src/main/java/com/swyp/server/domain/todo/entity/TodoCategory.java
+++ b/src/main/java/com/swyp/server/domain/todo/entity/TodoCategory.java
@@ -1,0 +1,13 @@
+package com.swyp.server.domain.todo.entity;
+
+public enum TodoCategory {
+    STUDY,
+    HOMEWORK,
+    READING,
+    ACTIVITY,
+    CLEANING,
+    HELPING,
+    HEALTH,
+    MIND,
+    FOCUS
+}

--- a/src/main/java/com/swyp/server/domain/todo/entity/TodoCategory.java
+++ b/src/main/java/com/swyp/server/domain/todo/entity/TodoCategory.java
@@ -1,21 +1,15 @@
 package com.swyp.server.domain.todo.entity;
 
-import static com.swyp.server.domain.todo.entity.TodoColor.*;
-
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
 public enum TodoCategory {
-    STUDY(RED),
-    HOMEWORK(PINK),
-    READING(PURPLE),
-    CREATIVITY(BLUE),
-    HEALTH(SKYBLUE),
-    ORGANIZATION(MINT),
-    FOCUS(EMERALD),
-    HOUSEHOLD(LIME);
-
-    private final TodoColor color;
+    STUDY,
+    HOMEWORK,
+    READING,
+    CREATIVITY,
+    HEALTH,
+    ORGANIZATION,
+    FOCUS,
+    HOUSEHOLD
 }

--- a/src/main/java/com/swyp/server/domain/todo/entity/TodoColor.java
+++ b/src/main/java/com/swyp/server/domain/todo/entity/TodoColor.java
@@ -1,0 +1,16 @@
+package com.swyp.server.domain.todo.entity;
+
+public enum TodoColor {
+    RED,
+    PINK,
+    PURPLE,
+    BLUE,
+    SKYBLUE,
+    MINT,
+    EMERALD,
+    LIME,
+    YELLOW,
+    ORANGE,
+    BROWN,
+    GRAY
+}

--- a/src/main/java/com/swyp/server/domain/todo/entity/TodoColor.java
+++ b/src/main/java/com/swyp/server/domain/todo/entity/TodoColor.java
@@ -1,5 +1,8 @@
 package com.swyp.server.domain.todo.entity;
 
+import lombok.Getter;
+
+@Getter
 public enum TodoColor {
     RED,
     PINK,

--- a/src/main/java/com/swyp/server/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/com/swyp/server/domain/todo/repository/TodoRepository.java
@@ -11,7 +11,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface TodoRepository extends JpaRepository<Todo, Long> {
-    List<Todo> findAllByUserIdAndTodoDate(Long userId, LocalDate todoDate);
+    List<Todo> findAllByUserIdAndTodoDateOrderByCompletedAscCreatedAtAsc(
+            Long userId, LocalDate todoDate);
 
     Optional<Todo> findByIdAndUserId(Long todoId, Long userId);
 

--- a/src/main/java/com/swyp/server/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/com/swyp/server/domain/todo/repository/TodoRepository.java
@@ -18,6 +18,8 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
     void deleteByUserId(Long userId);
 
     @Modifying
-    @Query("delete from Todo t where t.deletedAt is not null and t.deletedAt <= :cutoff")
+    @Query(
+            value = "DELETE FROM todos WHERE deleted_at IS NOT NULL AND deleted_at <= :cutoff",
+            nativeQuery = true)
     int deleteAllDeletedBefore(@Param("cutoff") LocalDateTime cutoff);
 }

--- a/src/main/java/com/swyp/server/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/com/swyp/server/domain/todo/repository/TodoRepository.java
@@ -15,7 +15,9 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
 
     Optional<Todo> findByIdAndUserId(Long todoId, Long userId);
 
-    void deleteByUserId(Long userId);
+    @Modifying
+    @Query(value = "DELETE FROM todos WHERE user_id = :userId", nativeQuery = true)
+    void hardDeleteAllByUserId(@Param("userId") Long userId);
 
     @Modifying
     @Query(

--- a/src/main/java/com/swyp/server/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/com/swyp/server/domain/todo/repository/TodoRepository.java
@@ -7,7 +7,7 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TodoRepository extends JpaRepository<Todo, Long> {
-    List<Todo> findAllByUserIDAndTodoDate(Long userId, LocalDate todoDate);
+    List<Todo> findAllByUserIdAndTodoDate(Long userId, LocalDate todoDate);
 
     Optional<Todo> findByIdAndUserId(Long todoId, Long userId);
 }

--- a/src/main/java/com/swyp/server/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/com/swyp/server/domain/todo/repository/TodoRepository.java
@@ -2,12 +2,22 @@ package com.swyp.server.domain.todo.repository;
 
 import com.swyp.server.domain.todo.entity.Todo;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TodoRepository extends JpaRepository<Todo, Long> {
     List<Todo> findAllByUserIdAndTodoDate(Long userId, LocalDate todoDate);
 
     Optional<Todo> findByIdAndUserId(Long todoId, Long userId);
+
+    void deleteByUserId(Long userId);
+
+    @Modifying
+    @Query("delete from Todo t where t.deletedAt is not null and t.deletedAt <= :cutoff")
+    int deleteAllDeletedBefore(@Param("cutoff") LocalDateTime cutoff);
 }

--- a/src/main/java/com/swyp/server/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/com/swyp/server/domain/todo/repository/TodoRepository.java
@@ -1,0 +1,13 @@
+package com.swyp.server.domain.todo.repository;
+
+import com.swyp.server.domain.todo.entity.Todo;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TodoRepository extends JpaRepository<Todo, Long> {
+    List<Todo> findAllByUserIDAndTodoDate(Long userId, LocalDate todoDate);
+
+    Optional<Todo> findByIdAndUserId(Long todoId, Long userId);
+}

--- a/src/main/java/com/swyp/server/domain/todo/service/TodoScheduler.java
+++ b/src/main/java/com/swyp/server/domain/todo/service/TodoScheduler.java
@@ -1,0 +1,27 @@
+package com.swyp.server.domain.todo.service;
+
+import com.swyp.server.domain.todo.repository.TodoRepository;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TodoScheduler {
+
+    private final TodoRepository todoRepository;
+
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    @Transactional
+    public void hardDeleteTodos() {
+        LocalDateTime cutoff = LocalDateTime.now(ZoneId.of("Asia/Seoul")).minusDays(30);
+        int deletedCount = todoRepository.deleteAllDeletedBefore(cutoff);
+
+        log.info("Hard deleted {} todos", deletedCount);
+    }
+}

--- a/src/main/java/com/swyp/server/domain/todo/service/TodoService.java
+++ b/src/main/java/com/swyp/server/domain/todo/service/TodoService.java
@@ -82,7 +82,7 @@ public class TodoService {
                         .findByIdAndUserId(todoId, userId)
                         .orElseThrow(() -> new CustomException(ErrorCode.TODO_NOT_FOUND));
 
-        todoRepository.delete(todo);
+        todo.delete();
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/swyp/server/domain/todo/service/TodoService.java
+++ b/src/main/java/com/swyp/server/domain/todo/service/TodoService.java
@@ -46,8 +46,10 @@ public class TodoService {
             TodoCategory category,
             LocalDate todoDate,
             Boolean completed) {
-        Todo todo = todoRepository.findByIdAndUserId(todoId, userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.TODO_NOT_FOUND));
+        Todo todo =
+                todoRepository
+                        .findByIdAndUserId(todoId, userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.TODO_NOT_FOUND));
 
         if (title != null) {
             if (title.isBlank()) {
@@ -71,6 +73,16 @@ public class TodoService {
                 todo.incomplete();
             }
         }
+    }
+
+    @Transactional
+    public void deleteTodo(Long userId, Long todoId) {
+        Todo todo =
+                todoRepository
+                        .findByIdAndUserId(todoId, userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.TODO_NOT_FOUND));
+
+        todoRepository.delete(todo);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/swyp/server/domain/todo/service/TodoService.java
+++ b/src/main/java/com/swyp/server/domain/todo/service/TodoService.java
@@ -21,7 +21,7 @@ public class TodoService {
     private final UserRepository userRepository;
 
     @Transactional
-    public Long createTodo(Long userId, String title, TodoCategory category, LocalDate todoDate) {
+    public Todo createTodo(Long userId, String title, TodoCategory category, LocalDate todoDate) {
         User user =
                 userRepository
                         .findById(userId)
@@ -35,7 +35,7 @@ public class TodoService {
                         .todoDate(todoDate)
                         .build();
 
-        return todoRepository.save(todo).getId();
+        return todoRepository.save(todo);
     }
 
     @Transactional

--- a/src/main/java/com/swyp/server/domain/todo/service/TodoService.java
+++ b/src/main/java/com/swyp/server/domain/todo/service/TodoService.java
@@ -8,6 +8,7 @@ import com.swyp.server.domain.user.repository.UserRepository;
 import com.swyp.server.global.exception.CustomException;
 import com.swyp.server.global.exception.ErrorCode;
 import java.time.LocalDate;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,5 +36,10 @@ public class TodoService {
                         .build();
 
         return todoRepository.save(todo).getId();
+    }
+
+    @Transactional(readOnly = true)
+    public List<Todo> getTodosByDate(Long userId, LocalDate date) {
+        return todoRepository.findAllByUserIdAndTodoDate(userId, date);
     }
 }

--- a/src/main/java/com/swyp/server/domain/todo/service/TodoService.java
+++ b/src/main/java/com/swyp/server/domain/todo/service/TodoService.java
@@ -2,6 +2,7 @@ package com.swyp.server.domain.todo.service;
 
 import com.swyp.server.domain.todo.entity.Todo;
 import com.swyp.server.domain.todo.entity.TodoCategory;
+import com.swyp.server.domain.todo.entity.TodoColor;
 import com.swyp.server.domain.todo.repository.TodoRepository;
 import com.swyp.server.domain.user.entity.User;
 import com.swyp.server.domain.user.repository.UserRepository;
@@ -21,7 +22,8 @@ public class TodoService {
     private final UserRepository userRepository;
 
     @Transactional
-    public Todo createTodo(Long userId, String title, TodoCategory category, LocalDate todoDate) {
+    public Todo createTodo(
+            Long userId, String title, TodoCategory category, TodoColor color, LocalDate todoDate) {
         User user =
                 userRepository
                         .findById(userId)
@@ -32,6 +34,7 @@ public class TodoService {
                         .user(user)
                         .title(title)
                         .category(category)
+                        .color(color)
                         .todoDate(todoDate)
                         .build();
 
@@ -44,6 +47,7 @@ public class TodoService {
             Long todoId,
             String title,
             TodoCategory category,
+            TodoColor color,
             LocalDate todoDate,
             Boolean completed) {
         Todo todo =
@@ -60,6 +64,10 @@ public class TodoService {
 
         if (category != null) {
             todo.updateCategory(category);
+        }
+
+        if (color != null) {
+            todo.updateColor(color);
         }
 
         if (todoDate != null) {

--- a/src/main/java/com/swyp/server/domain/todo/service/TodoService.java
+++ b/src/main/java/com/swyp/server/domain/todo/service/TodoService.java
@@ -1,0 +1,39 @@
+package com.swyp.server.domain.todo.service;
+
+import com.swyp.server.domain.todo.entity.Todo;
+import com.swyp.server.domain.todo.entity.TodoCategory;
+import com.swyp.server.domain.todo.repository.TodoRepository;
+import com.swyp.server.domain.user.entity.User;
+import com.swyp.server.domain.user.repository.UserRepository;
+import com.swyp.server.global.exception.CustomException;
+import com.swyp.server.global.exception.ErrorCode;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TodoService {
+
+    private final TodoRepository todoRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public Long createTodo(Long userId, String title, TodoCategory category, LocalDate todoDate) {
+        User user =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        Todo todo =
+                Todo.builder()
+                        .user(user)
+                        .title(title)
+                        .category(category)
+                        .todoDate(todoDate)
+                        .build();
+
+        return todoRepository.save(todo).getId();
+    }
+}

--- a/src/main/java/com/swyp/server/domain/todo/service/TodoService.java
+++ b/src/main/java/com/swyp/server/domain/todo/service/TodoService.java
@@ -38,6 +38,41 @@ public class TodoService {
         return todoRepository.save(todo).getId();
     }
 
+    @Transactional
+    public void updateTodo(
+            Long userId,
+            Long todoId,
+            String title,
+            TodoCategory category,
+            LocalDate todoDate,
+            Boolean completed) {
+        Todo todo = todoRepository.findByIdAndUserId(todoId, userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.TODO_NOT_FOUND));
+
+        if (title != null) {
+            if (title.isBlank()) {
+                throw new CustomException(ErrorCode.TODO_TITLE_REQUIRED);
+            }
+            todo.updateTitle(title);
+        }
+
+        if (category != null) {
+            todo.updateCategory(category);
+        }
+
+        if (todoDate != null) {
+            todo.updateTodoDate(todoDate);
+        }
+
+        if (completed != null) {
+            if (completed) {
+                todo.complete();
+            } else {
+                todo.incomplete();
+            }
+        }
+    }
+
     @Transactional(readOnly = true)
     public List<Todo> getTodosByDate(Long userId, LocalDate date) {
         return todoRepository.findAllByUserIdAndTodoDate(userId, date);

--- a/src/main/java/com/swyp/server/domain/todo/service/TodoService.java
+++ b/src/main/java/com/swyp/server/domain/todo/service/TodoService.java
@@ -95,6 +95,7 @@ public class TodoService {
 
     @Transactional(readOnly = true)
     public List<Todo> getTodosByDate(Long userId, LocalDate date) {
-        return todoRepository.findAllByUserIdAndTodoDate(userId, date);
+        return todoRepository.findAllByUserIdAndTodoDateOrderByCompletedAscCreatedAtAsc(
+                userId, date);
     }
 }

--- a/src/main/java/com/swyp/server/domain/user/service/UserWithdrawalScheduler.java
+++ b/src/main/java/com/swyp/server/domain/user/service/UserWithdrawalScheduler.java
@@ -1,5 +1,6 @@
 package com.swyp.server.domain.user.service;
 
+import com.swyp.server.domain.todo.repository.TodoRepository;
 import com.swyp.server.domain.user.entity.User;
 import com.swyp.server.domain.user.repository.UserRepository;
 import com.swyp.server.infra.fcm.repository.FcmTokenRepository;
@@ -19,6 +20,7 @@ public class UserWithdrawalScheduler {
 
     private final UserRepository userRepository;
     private final FcmTokenRepository fcmTokenRepository;
+    private final TodoRepository todoRepository;
 
     @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
     @Transactional
@@ -31,6 +33,8 @@ public class UserWithdrawalScheduler {
         }
 
         deletedUsers.forEach(user -> fcmTokenRepository.deleteByUserId(user.getId()));
+        deletedUsers.forEach(user -> todoRepository.deleteByUserId(user.getId()));
+
         userRepository.deleteAll(deletedUsers);
         log.info("Hard deleted {} withdrawn users", deletedUsers.size());
     }

--- a/src/main/java/com/swyp/server/domain/user/service/UserWithdrawalScheduler.java
+++ b/src/main/java/com/swyp/server/domain/user/service/UserWithdrawalScheduler.java
@@ -33,7 +33,7 @@ public class UserWithdrawalScheduler {
         }
 
         deletedUsers.forEach(user -> fcmTokenRepository.deleteByUserId(user.getId()));
-        deletedUsers.forEach(user -> todoRepository.deleteByUserId(user.getId()));
+        deletedUsers.forEach(user -> todoRepository.hardDeleteAllByUserId(user.getId()));
 
         userRepository.deleteAll(deletedUsers);
         log.info("Hard deleted {} withdrawn users", deletedUsers.size());

--- a/src/main/java/com/swyp/server/global/exception/ErrorCode.java
+++ b/src/main/java/com/swyp/server/global/exception/ErrorCode.java
@@ -44,7 +44,7 @@ public enum ErrorCode {
 
     TODO_TITLE_REQUIRED(40009, 400, "할 일 제목은 필수입니다."),
     TODO_TITLE_LENGTH_INVALID(40010, 400, "할 일 제목은 50자 이하여야 합니다."),
-    TODO_CATEGORY_CATEGORY_REQUIRED(40011, 400, "할 일 카테고리는 필수입니다."),
+    TODO_CATEGORY_REQUIRED(40011, 400, "할 일 카테고리는 필수입니다."),
     TODO_DATE_REQUIRED(40012, 400, "할 일 날짜는 필수입니다.");
 
     private final int code;

--- a/src/main/java/com/swyp/server/global/exception/ErrorCode.java
+++ b/src/main/java/com/swyp/server/global/exception/ErrorCode.java
@@ -22,6 +22,9 @@ public enum ErrorCode {
     USER_NOT_FOUND(40401, 404, "사용자를 찾을 수 없습니다."),
     DUPLICATE_EMAIL(40901, 409, "이미 사용 중인 이메일입니다."),
 
+    // Todos
+    TODO_NOT_FOUND(40402, 404, "할 일을 찾을 수 없습니다."),
+
     // FCM
     FCM_SEND_FAILED(50001, 500, "푸시 알림 전송에 실패했습니다."),
     FCM_TOPIC_SUBSCRIBE_FAILED(50002, 500, "푸시 토픽 구독에 실패했습니다."),
@@ -32,7 +35,13 @@ public enum ErrorCode {
     PLATFORM_REQUIRED(40002, 400, "플랫폼은 필수입니다."),
 
     SOCIAL_TYPE_REQUIRED(40003, 400, "소셜 타입은 필수입니다."),
-    SOCIAL_TOKEN_REQUIRED(40004, 400, "소셜 토큰은 필수입니다.");
+    SOCIAL_TOKEN_REQUIRED(40004, 400, "소셜 토큰은 필수입니다."),
+
+    TODO_TITLE_REQUIRED(40009,400,"할 일 제목은 필수입니다."),
+    TODO_TITLE_LENGTH_INVALID(40010,400,"할 일 제목은 50자 이하여야 합니다."),
+    TODO_CATEGORY_CATEGORY_REQUIRED(40011,400,"할 일 카테고리는 필수입니다."),
+    TODO_DATE_REQUIRED(40012,400,"할 일 날짜는 필수입니다.");
+
 
     private final int code;
     private final int status;

--- a/src/main/java/com/swyp/server/global/exception/ErrorCode.java
+++ b/src/main/java/com/swyp/server/global/exception/ErrorCode.java
@@ -37,11 +37,10 @@ public enum ErrorCode {
     SOCIAL_TYPE_REQUIRED(40003, 400, "소셜 타입은 필수입니다."),
     SOCIAL_TOKEN_REQUIRED(40004, 400, "소셜 토큰은 필수입니다."),
 
-    TODO_TITLE_REQUIRED(40009,400,"할 일 제목은 필수입니다."),
-    TODO_TITLE_LENGTH_INVALID(40010,400,"할 일 제목은 50자 이하여야 합니다."),
-    TODO_CATEGORY_CATEGORY_REQUIRED(40011,400,"할 일 카테고리는 필수입니다."),
-    TODO_DATE_REQUIRED(40012,400,"할 일 날짜는 필수입니다.");
-
+    TODO_TITLE_REQUIRED(40009, 400, "할 일 제목은 필수입니다."),
+    TODO_TITLE_LENGTH_INVALID(40010, 400, "할 일 제목은 50자 이하여야 합니다."),
+    TODO_CATEGORY_CATEGORY_REQUIRED(40011, 400, "할 일 카테고리는 필수입니다."),
+    TODO_DATE_REQUIRED(40012, 400, "할 일 날짜는 필수입니다.");
 
     private final int code;
     private final int status;

--- a/src/main/java/com/swyp/server/global/exception/ErrorCode.java
+++ b/src/main/java/com/swyp/server/global/exception/ErrorCode.java
@@ -43,7 +43,7 @@ public enum ErrorCode {
     USER_TYPE_REQUIRED(40008, 400, "사용자 유형은 필수입니다."),
 
     TODO_TITLE_REQUIRED(40009, 400, "할 일 제목은 필수입니다."),
-    TODO_TITLE_LENGTH_INVALID(40010, 400, "할 일 제목은 50자 이하여야 합니다."),
+    TODO_TITLE_LENGTH_INVALID(40010, 400, "할 일 제목은 12자 이하여야 합니다."),
     TODO_CATEGORY_REQUIRED(40011, 400, "할 일 카테고리는 필수입니다."),
     TODO_DATE_REQUIRED(40012, 400, "할 일 날짜는 필수입니다.");
 

--- a/src/main/java/com/swyp/server/global/exception/ErrorCode.java
+++ b/src/main/java/com/swyp/server/global/exception/ErrorCode.java
@@ -45,7 +45,8 @@ public enum ErrorCode {
     TODO_TITLE_REQUIRED(40009, 400, "할 일 제목은 필수입니다."),
     TODO_TITLE_LENGTH_INVALID(40010, 400, "할 일 제목은 12자 이하여야 합니다."),
     TODO_CATEGORY_REQUIRED(40011, 400, "할 일 카테고리는 필수입니다."),
-    TODO_DATE_REQUIRED(40012, 400, "할 일 날짜는 필수입니다.");
+    TODO_DATE_REQUIRED(40012, 400, "할 일 날짜는 필수입니다."),
+    TODO_COLOR_REQUIRED(40013, 400, "할 일 색상은 필수입니다.");
 
     private final int code;
     private final int status;


### PR DESCRIPTION
## 📌 관련 이슈
- close #34 

## ✨ 변경 사항
- Todo 엔티티 설계
- User - Todo 다대일 연관 관계 설정
- Todo 생성/조회/수정/삭제 API 구현
- Todo 카테고리별 색상 정보 추가
- Todo soft delete 적용
- soft delete 된 Todo 30일 후 hard delete하는 스케쥴러 추가

## 📸 테스트 증명 (필수)
구글 로그인 후 Todo CRUD API 정상 동작 확인했습니다.
soft delete 된 todo 조회 안되는거 확인했습니다.
스케쥴링 cron 수정해서 정상 동작 확인했습니다.

## 📚 리뷰어 참고 사항

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요?
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?
- [x] spotlessApply 실행했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Todo management API: create, list-by-date (with per-day counts & progress), update, delete.
  * New DTOs and entity: todo details, lists, responses, categories and colors, and completion state.
  * Background jobs: daily hard-delete of old soft-deleted todos and removal of todos when users withdraw.

* **Bug Fixes**
  * Validation and clearer error responses for missing/invalid todo fields (title, category, color, date).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->