### PR TITLE
[Feat/#37] 이용약관 동의 저장 API 구현

### DIFF
--- a/src/main/java/com/swyp/server/domain/user/controller/UserController.java
+++ b/src/main/java/com/swyp/server/domain/user/controller/UserController.java
@@ -37,4 +37,11 @@ public class UserController {
         userService.withdraw(userId);
         return ResponseEntity.ok(ApiResponse.success(null));
     }
+
+    @Operation(summary = "이용약관 동의")
+    @PatchMapping("/me/terms")
+    public ResponseEntity<ApiResponse<Void>> agreeToTerms(@AuthenticationPrincipal Long userId) {
+        userService.agreeToTerms(userId);
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
 }

--- a/src/main/java/com/swyp/server/domain/user/entity/User.java
+++ b/src/main/java/com/swyp/server/domain/user/entity/User.java
@@ -9,6 +9,8 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -41,6 +43,11 @@ public class User extends SoftDeletableEntity {
     @Column(nullable = false)
     private boolean profileCompleted;
 
+    @Column(nullable = false)
+    private boolean termsAgreed;
+
+    @Column private LocalDateTime termsAgreedAt;
+
     @Builder
     public User(String email, String nickname, String profileImageUrl, Role role) {
         this.email = email;
@@ -59,5 +66,10 @@ public class User extends SoftDeletableEntity {
         this.nickname = nickname;
         this.userType = userType;
         this.profileCompleted = true;
+    }
+
+    public void agreeToTerms() {
+        this.termsAgreed = true;
+        this.termsAgreedAt = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
     }
 }

--- a/src/main/java/com/swyp/server/domain/user/service/UserService.java
+++ b/src/main/java/com/swyp/server/domain/user/service/UserService.java
@@ -66,4 +66,13 @@ public class UserService {
         fcmTokenRepository.deleteByUserId(userId);
         user.delete();
     }
+
+    @Transactional
+    public void agreeToTerms(Long userId) {
+        User user =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        user.agreeToTerms();
+    }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #37

## ✨ 변경 사항
- PATCH /api/v1/users/me/terms 이용약관 동의 API 구현
- User 엔티티에 termsAgreed, termsAgreedAt 필드 추가
- 동의 시각 Asia/Seoul 기준으로 저장

## 📸 테스트 증명 (필수)
로컬 Swagger에서 PATCH /api/v1/users/me/terms 호출 후 DB termsAgreed, termsAgreedAt 저장 확인

## 📚 리뷰어 참고 사항
- 온보딩 플로우에서 이용약관 동의 후 호출하는 API입니다. 중복동의 시에도 termsAgreedAt이 갱신됩니다.

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요?
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?
- [x] spotlessApply 실행했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now formally agree to and accept the terms of service through a dedicated new endpoint. The system records agreement status and captures the exact date and time each user accepts the terms, enabling better tracking and compliance management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->