### PR TITLE
[Fix/#39] User 엔티티 soft delete 쿼리 필터 누락 수정

### DIFF
--- a/src/main/java/com/swyp/server/domain/user/controller/UserController.java
+++ b/src/main/java/com/swyp/server/domain/user/controller/UserController.java
@@ -37,4 +37,11 @@ public class UserController {
         userService.withdraw(userId);
         return ResponseEntity.ok(ApiResponse.success(null));
     }
+
+    @Operation(summary = "이용약관 동의")
+    @PatchMapping("/me/terms")
+    public ResponseEntity<ApiResponse<Void>> agreeToTerms(@AuthenticationPrincipal Long userId) {
+        userService.agreeToTerms(userId);
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
 }

--- a/src/main/java/com/swyp/server/domain/user/entity/User.java
+++ b/src/main/java/com/swyp/server/domain/user/entity/User.java
@@ -15,9 +15,11 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Table(name = "users")
+@SQLRestriction("deleted_at IS NULL")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends SoftDeletableEntity {

--- a/src/main/java/com/swyp/server/domain/user/entity/User.java
+++ b/src/main/java/com/swyp/server/domain/user/entity/User.java
@@ -9,6 +9,8 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -41,6 +43,11 @@ public class User extends SoftDeletableEntity {
     @Column(nullable = false)
     private boolean profileCompleted;
 
+    @Column(nullable = false)
+    private boolean termsAgreed;
+
+    @Column private LocalDateTime termsAgreedAt;
+
     @Builder
     public User(String email, String nickname, String profileImageUrl, Role role) {
         this.email = email;
@@ -59,5 +66,10 @@ public class User extends SoftDeletableEntity {
         this.nickname = nickname;
         this.userType = userType;
         this.profileCompleted = true;
+    }
+
+    public void agreeToTerms() {
+        this.termsAgreed = true;
+        this.termsAgreedAt = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
     }
 }

--- a/src/main/java/com/swyp/server/domain/user/service/UserService.java
+++ b/src/main/java/com/swyp/server/domain/user/service/UserService.java
@@ -66,4 +66,13 @@ public class UserService {
         fcmTokenRepository.deleteByUserId(userId);
         user.delete();
     }
+
+    @Transactional
+    public void agreeToTerms(Long userId) {
+        User user =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        user.agreeToTerms();
+    }
 }

--- a/src/main/java/com/swyp/server/global/SoftDeletableEntity.java
+++ b/src/main/java/com/swyp/server/global/SoftDeletableEntity.java
@@ -4,11 +4,9 @@ import jakarta.persistence.Column;
 import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
 import lombok.Getter;
-import org.hibernate.annotations.SQLRestriction;
 
 @Getter
 @MappedSuperclass
-@SQLRestriction("deleted_at IS NULL")
 public abstract class SoftDeletableEntity extends AuditableEntity {
 
     @Column private LocalDateTime deletedAt;


### PR DESCRIPTION
## 📌 관련 이슈
- close #39

## ✨ 변경 사항
- User.java에 @SQLRestriction 추가
- SoftDeletableEntity에서 @SQLRestriction 제거

## 📚 리뷰어 참고 사항
- SoftDeletableEntity에 @SQLRestriction이 선언되어 있으나 User 엔티티 조회 시 deleted_at IS NULL 조건이 쿼리에 포함되지 않는 문제
- User 엔티티에 @SQLRestriction("deleted_at IS NULL")를 직접 추가하여 해결함

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요?
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?
- [x] spotlessApply 실행했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can now agree to terms via a new API; agreement is recorded with a timestamp.
* **Bug Fixes**
  * Adjusted soft-delete behavior: deleted user records are now handled differently so deleted rows are excluded at the user level rather than globally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->