### PR TITLE
[Refactor/#41] Todo API 및 카테고리 수정

### DIFF
--- a/src/main/java/com/swyp/server/domain/todo/controller/TodoController.java
+++ b/src/main/java/com/swyp/server/domain/todo/controller/TodoController.java
@@ -43,7 +43,7 @@ public class TodoController {
                 .body(ApiResponse.created(TodoCreateResponse.from(todo)));
     }
 
-    @Operation(summary = "날짜별 할 일 조회")
+    @Operation(summary = "오늘의 할 일 조회")
     @GetMapping
     public ResponseEntity<ApiResponse<TodoListResponse>> getTodosByDate(
             @AuthenticationPrincipal Long userId) {

--- a/src/main/java/com/swyp/server/domain/todo/controller/TodoController.java
+++ b/src/main/java/com/swyp/server/domain/todo/controller/TodoController.java
@@ -10,7 +10,6 @@ import com.swyp.server.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -23,7 +22,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Todo", description = "할 일 API")
@@ -40,11 +38,7 @@ public class TodoController {
             @AuthenticationPrincipal Long userId, @Valid @RequestBody TodoCreateRequest request) {
         Todo todo =
                 todoService.createTodo(
-                        userId,
-                        request.title(),
-                        request.category(),
-                        request.color(),
-                        request.todoDate());
+                        userId, request.title(), request.category(), request.color());
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.created(TodoCreateResponse.from(todo)));
     }
@@ -52,9 +46,9 @@ public class TodoController {
     @Operation(summary = "날짜별 할 일 조회")
     @GetMapping
     public ResponseEntity<ApiResponse<TodoListResponse>> getTodosByDate(
-            @AuthenticationPrincipal Long userId, @RequestParam LocalDate date) {
+            @AuthenticationPrincipal Long userId) {
 
-        List<Todo> todos = todoService.getTodosByDate(userId, date);
+        List<Todo> todos = todoService.getTodos(userId);
         return ResponseEntity.ok(ApiResponse.success(TodoListResponse.from(todos)));
     }
 
@@ -71,7 +65,6 @@ public class TodoController {
                 request.title(),
                 request.category(),
                 request.color(),
-                request.todoDate(),
                 request.completed());
         return ResponseEntity.ok(ApiResponse.success(null));
     }

--- a/src/main/java/com/swyp/server/domain/todo/controller/TodoController.java
+++ b/src/main/java/com/swyp/server/domain/todo/controller/TodoController.java
@@ -45,10 +45,10 @@ public class TodoController {
 
     @Operation(summary = "오늘의 할 일 조회")
     @GetMapping
-    public ResponseEntity<ApiResponse<TodoListResponse>> getTodosByDate(
+    public ResponseEntity<ApiResponse<TodoListResponse>> getTodayTodos(
             @AuthenticationPrincipal Long userId) {
 
-        List<Todo> todos = todoService.getTodos(userId);
+        List<Todo> todos = todoService.getTodayTodos(userId);
         return ResponseEntity.ok(ApiResponse.success(TodoListResponse.from(todos)));
     }
 

--- a/src/main/java/com/swyp/server/domain/todo/dto/TodoCreateRequest.java
+++ b/src/main/java/com/swyp/server/domain/todo/dto/TodoCreateRequest.java
@@ -5,12 +5,10 @@ import com.swyp.server.domain.todo.entity.TodoColor;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import java.time.LocalDate;
 
 public record TodoCreateRequest(
         @NotBlank(message = "TODO_TITLE_REQUIRED")
                 @Size(max = 12, message = "TODO_TITLE_LENGTH_INVALID")
                 String title,
         @NotNull(message = "TODO_CATEGORY_REQUIRED") TodoCategory category,
-        @NotNull(message = "TODO_COLOR_REQUIRED") TodoColor color,
-        @NotNull(message = "TODO_DATE_REQUIRED") LocalDate todoDate) {}
+        @NotNull(message = "TODO_COLOR_REQUIRED") TodoColor color) {}

--- a/src/main/java/com/swyp/server/domain/todo/dto/TodoCreateResponse.java
+++ b/src/main/java/com/swyp/server/domain/todo/dto/TodoCreateResponse.java
@@ -3,22 +3,15 @@ package com.swyp.server.domain.todo.dto;
 import com.swyp.server.domain.todo.entity.Todo;
 import com.swyp.server.domain.todo.entity.TodoCategory;
 import com.swyp.server.domain.todo.entity.TodoColor;
-import java.time.LocalDate;
 
 public record TodoCreateResponse(
-        Long todoId,
-        String title,
-        TodoCategory category,
-        LocalDate todoDate,
-        TodoColor color,
-        boolean completed) {
+        Long todoId, String title, TodoCategory category, TodoColor color, boolean completed) {
 
     public static TodoCreateResponse from(Todo todo) {
         return new TodoCreateResponse(
                 todo.getId(),
                 todo.getTitle(),
                 todo.getCategory(),
-                todo.getTodoDate(),
                 todo.getColor(),
                 todo.isCompleted());
     }

--- a/src/main/java/com/swyp/server/domain/todo/entity/TodoCategory.java
+++ b/src/main/java/com/swyp/server/domain/todo/entity/TodoCategory.java
@@ -1,15 +1,18 @@
 package com.swyp.server.domain.todo.entity;
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
+@RequiredArgsConstructor
 public enum TodoCategory {
-    STUDY,
-    HOMEWORK,
-    READING,
-    CREATIVITY,
-    HEALTH,
-    ORGANIZATION,
-    FOCUS,
-    HOUSEHOLD
+    STUDY("공부"),
+    HOMEWORK("숙제"),
+    EXERCISE("운동"),
+    CLEANING("정리"),
+    READING("독서"),
+    HOUSEWORK("집안일"),
+    CREATIVE_ACTIVITY("창의활동");
+
+    private final String label;
 }

--- a/src/main/java/com/swyp/server/domain/todo/service/TodoService.java
+++ b/src/main/java/com/swyp/server/domain/todo/service/TodoService.java
@@ -91,7 +91,7 @@ public class TodoService {
     }
 
     @Transactional(readOnly = true)
-    public List<Todo> getTodos(Long userId) {
+    public List<Todo> getTodayTodos(Long userId) {
         LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
         return todoRepository.findAllByUserIdAndTodoDateOrderByCompletedAscCreatedAtAsc(
                 userId, today);

--- a/src/main/java/com/swyp/server/domain/todo/service/TodoService.java
+++ b/src/main/java/com/swyp/server/domain/todo/service/TodoService.java
@@ -9,6 +9,7 @@ import com.swyp.server.domain.user.repository.UserRepository;
 import com.swyp.server.global.exception.CustomException;
 import com.swyp.server.global.exception.ErrorCode;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -22,8 +23,9 @@ public class TodoService {
     private final UserRepository userRepository;
 
     @Transactional
-    public Todo createTodo(
-            Long userId, String title, TodoCategory category, TodoColor color, LocalDate todoDate) {
+    public Todo createTodo(Long userId, String title, TodoCategory category, TodoColor color) {
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+
         User user =
                 userRepository
                         .findById(userId)
@@ -35,7 +37,7 @@ public class TodoService {
                         .title(title)
                         .category(category)
                         .color(color)
-                        .todoDate(todoDate)
+                        .todoDate(today)
                         .build();
 
         return todoRepository.save(todo);
@@ -48,7 +50,6 @@ public class TodoService {
             String title,
             TodoCategory category,
             TodoColor color,
-            LocalDate todoDate,
             Boolean completed) {
         Todo todo =
                 todoRepository
@@ -68,10 +69,6 @@ public class TodoService {
 
         if (color != null) {
             todo.updateColor(color);
-        }
-
-        if (todoDate != null) {
-            todo.updateTodoDate(todoDate);
         }
 
         if (completed != null) {
@@ -94,8 +91,9 @@ public class TodoService {
     }
 
     @Transactional(readOnly = true)
-    public List<Todo> getTodosByDate(Long userId, LocalDate date) {
+    public List<Todo> getTodos(Long userId) {
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
         return todoRepository.findAllByUserIdAndTodoDateOrderByCompletedAscCreatedAtAsc(
-                userId, date);
+                userId, today);
     }
 }

--- a/src/main/java/com/swyp/server/global/exception/ErrorCode.java
+++ b/src/main/java/com/swyp/server/global/exception/ErrorCode.java
@@ -45,7 +45,6 @@ public enum ErrorCode {
     TODO_TITLE_REQUIRED(40009, 400, "할 일 제목은 필수입니다."),
     TODO_TITLE_LENGTH_INVALID(40010, 400, "할 일 제목은 12자 이하여야 합니다."),
     TODO_CATEGORY_REQUIRED(40011, 400, "할 일 카테고리는 필수입니다."),
-    TODO_DATE_REQUIRED(40012, 400, "할 일 날짜는 필수입니다."),
     TODO_COLOR_REQUIRED(40013, 400, "할 일 색상은 필수입니다.");
 
     private final int code;


### PR DESCRIPTION
## 📌 관련 이슈
- close #41 

## ✨ 변경 사항
- Todo 요청과 응답시 todoDate 필드 삭제
- Todo 카테고리 label 추가 및 네이밍 수정

## 📸 테스트 증명 (필수)
Todo CRUD API 테스트 정상 작동 확인했습니다.

## 📚 리뷰어 참고 사항
Todo Category enum 상수 목록 변경되어서 
`docker compose down -v` 
통해서 테이블 DROP 시켜야합니다.

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요?
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?
- [x] spotlessApply 실행했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Todos no longer accept a user-supplied date; they’re assigned to the current date in Seoul timezone.
  * Creation and update flows no longer include a date field; responses no longer show a todo date.
  * The “date required” validation/error for todos has been removed.
  * Todo categories have been updated and relabeled (category names adjusted for clarity).

* **UX**
  * Endpoint/view for fetching todos now returns “Today’s todos” by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->