### PR TITLE
[Feat/#45] 내 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/swyp/server/domain/user/controller/UserController.java
+++ b/src/main/java/com/swyp/server/domain/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.swyp.server.domain.user.controller;
 
 import com.swyp.server.domain.user.dto.ProfileRequest;
+import com.swyp.server.domain.user.dto.UserResponse;
 import com.swyp.server.domain.user.service.UserService;
 import com.swyp.server.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -9,11 +10,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "User", description = "유저 API")
 @RestController
@@ -22,6 +19,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
 
     private final UserService userService;
+
+    @Operation(summary = "내 정보 조회")
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<UserResponse>> getMe(@AuthenticationPrincipal Long userId) {
+        return ResponseEntity.ok(ApiResponse.success(userService.getMe(userId)));
+    }
 
     @Operation(summary = "내 프로필 설정")
     @PatchMapping("/me")

--- a/src/main/java/com/swyp/server/domain/user/dto/UserResponse.java
+++ b/src/main/java/com/swyp/server/domain/user/dto/UserResponse.java
@@ -1,10 +1,22 @@
 package com.swyp.server.domain.user.dto;
 
 import com.swyp.server.domain.user.entity.User;
+import com.swyp.server.domain.user.entity.UserType;
 
-public record UserResponse(Long id, String email, String nickname, String profileImageUrl) {
+public record UserResponse(
+        Long id,
+        String email,
+        String nickname,
+        UserType userType,
+        boolean profileCompleted,
+        boolean termsAgreed) {
     public static UserResponse from(User user) {
         return new UserResponse(
-                user.getId(), user.getEmail(), user.getNickname(), user.getProfileImageUrl());
+                user.getId(),
+                user.getEmail(),
+                user.getNickname(),
+                user.getUserType(),
+                user.isProfileCompleted(),
+                user.isTermsAgreed());
     }
 }

--- a/src/main/java/com/swyp/server/domain/user/service/UserService.java
+++ b/src/main/java/com/swyp/server/domain/user/service/UserService.java
@@ -1,6 +1,7 @@
 package com.swyp.server.domain.user.service;
 
 import com.swyp.server.domain.auth.repository.RefreshTokenRepository;
+import com.swyp.server.domain.user.dto.UserResponse;
 import com.swyp.server.domain.user.entity.Role;
 import com.swyp.server.domain.user.entity.User;
 import com.swyp.server.domain.user.entity.UserType;
@@ -45,6 +46,15 @@ public class UserService {
         return userRepository
                 .findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    @Transactional(readOnly = true)
+    public UserResponse getMe(Long userId) {
+        User user =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        return UserResponse.from(user);
     }
 
     @Transactional


### PR DESCRIPTION
## 📌 관련 이슈
- close #45

## ✨ 변경 사항
- GET /api/v1/users/me 구현
- UserResponse 필드 수정

## 📸 테스트 증명 (필수)
<img width="929" height="762" alt="image" src="https://github.com/user-attachments/assets/96e7b28f-53b8-41fa-97f3-9e1b920b6c29" />

## 📚 리뷰어 참고 사항
- 기존 UserResponse에서 profileImageUrl 제거

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요?
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?
- [x] spotlessApply 실행했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new endpoint to retrieve current user information, including user type, profile completion status, and terms agreement status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->