### PR TITLE
[Feat/#46] Sticker 기본 구조 및 조회 로직 구현

### DIFF
--- a/src/main/java/com/swyp/server/domain/sticker/controller/StickerController.java
+++ b/src/main/java/com/swyp/server/domain/sticker/controller/StickerController.java
@@ -1,0 +1,32 @@
+package com.swyp.server.domain.sticker.controller;
+
+import com.swyp.server.domain.sticker.dto.WeeklyStickerResponse;
+import com.swyp.server.domain.sticker.service.StickerQueryService;
+import com.swyp.server.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Sticker", description = "스티커 API")
+@RestController
+@RequestMapping("/api/v1/stickers")
+@RequiredArgsConstructor
+public class StickerController {
+
+    private final StickerQueryService stickerQueryService;
+
+    @GetMapping("/weekly")
+    public ResponseEntity<ApiResponse<WeeklyStickerResponse>> getWeeklyStickers(
+            @AuthenticationPrincipal Long userId) {
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        WeeklyStickerResponse response = stickerQueryService.getWeeklyStickers(userId, today);
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/swyp/server/domain/sticker/controller/StickerController.java
+++ b/src/main/java/com/swyp/server/domain/sticker/controller/StickerController.java
@@ -1,8 +1,11 @@
 package com.swyp.server.domain.sticker.controller;
 
+import com.swyp.server.domain.sticker.dto.StickerBoardResponse;
 import com.swyp.server.domain.sticker.dto.WeeklyStickerResponse;
 import com.swyp.server.domain.sticker.service.StickerQueryService;
+import com.swyp.server.domain.sticker.service.StickerService;
 import com.swyp.server.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDate;
 import java.time.ZoneId;
@@ -10,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,7 +24,9 @@ import org.springframework.web.bind.annotation.RestController;
 public class StickerController {
 
     private final StickerQueryService stickerQueryService;
+    private final StickerService stickerService;
 
+    @Operation(summary = "주간 스티커 조회")
     @GetMapping("/weekly")
     public ResponseEntity<ApiResponse<WeeklyStickerResponse>> getWeeklyStickers(
             @AuthenticationPrincipal Long userId) {
@@ -28,5 +34,21 @@ public class StickerController {
         WeeklyStickerResponse response = stickerQueryService.getWeeklyStickers(userId, today);
 
         return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "스티커판 조회")
+    @GetMapping("/board")
+    public ResponseEntity<ApiResponse<StickerBoardResponse>> getStickerBoard(
+            @AuthenticationPrincipal Long userId) {
+        StickerBoardResponse response = stickerQueryService.getStickerBoard(userId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "스티커판 완료 팝업 확인")
+    @PostMapping("/board/confirm")
+    public ResponseEntity<ApiResponse<Void>> confirmStickerBoard(
+            @AuthenticationPrincipal Long userId) {
+        stickerService.confirmStickerBoard(userId);
+        return ResponseEntity.ok(ApiResponse.success(null));
     }
 }

--- a/src/main/java/com/swyp/server/domain/sticker/dto/CompletedDateStickerResponse.java
+++ b/src/main/java/com/swyp/server/domain/sticker/dto/CompletedDateStickerResponse.java
@@ -1,0 +1,5 @@
+package com.swyp.server.domain.sticker.dto;
+
+import java.time.LocalDate;
+
+public record CompletedDateStickerResponse(LocalDate date, String stickerCode) {}

--- a/src/main/java/com/swyp/server/domain/sticker/dto/CompletedDateStickerResponse.java
+++ b/src/main/java/com/swyp/server/domain/sticker/dto/CompletedDateStickerResponse.java
@@ -1,5 +1,0 @@
-package com.swyp.server.domain.sticker.dto;
-
-import java.time.LocalDate;
-
-public record CompletedDateStickerResponse(LocalDate date, String stickerCode) {}

--- a/src/main/java/com/swyp/server/domain/sticker/dto/DateStickerResponse.java
+++ b/src/main/java/com/swyp/server/domain/sticker/dto/DateStickerResponse.java
@@ -1,0 +1,5 @@
+package com.swyp.server.domain.sticker.dto;
+
+import java.time.LocalDate;
+
+public record DateStickerResponse(LocalDate date, String stickerCode) {}

--- a/src/main/java/com/swyp/server/domain/sticker/dto/StickerBoardResponse.java
+++ b/src/main/java/com/swyp/server/domain/sticker/dto/StickerBoardResponse.java
@@ -1,0 +1,3 @@
+package com.swyp.server.domain.sticker.dto;
+
+public record StickerBoardResponse(int boardSize, int filledSlotCount, boolean showCompletePopup) {}

--- a/src/main/java/com/swyp/server/domain/sticker/dto/WeeklyStickerResponse.java
+++ b/src/main/java/com/swyp/server/domain/sticker/dto/WeeklyStickerResponse.java
@@ -7,4 +7,4 @@ public record WeeklyStickerResponse(
         String weekLabel,
         LocalDate startDate,
         LocalDate endDate,
-        List<CompletedDateStickerResponse> stickers) {}
+        List<DateStickerResponse> stickers) {}

--- a/src/main/java/com/swyp/server/domain/sticker/dto/WeeklyStickerResponse.java
+++ b/src/main/java/com/swyp/server/domain/sticker/dto/WeeklyStickerResponse.java
@@ -1,0 +1,10 @@
+package com.swyp.server.domain.sticker.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record WeeklyStickerResponse(
+        String weekLabel,
+        LocalDate startDate,
+        LocalDate endDate,
+        List<CompletedDateStickerResponse> stickers) {}

--- a/src/main/java/com/swyp/server/domain/sticker/entity/Sticker.java
+++ b/src/main/java/com/swyp/server/domain/sticker/entity/Sticker.java
@@ -1,0 +1,44 @@
+package com.swyp.server.domain.sticker.entity;
+
+import com.swyp.server.global.AuditableEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "stickers")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Sticker extends AuditableEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 50)
+    private String code;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column(nullable = false)
+    private boolean basic;
+
+    @Column(length = 500)
+    private String imageUrl;
+
+    @Builder
+    public Sticker(String code, String name, boolean basic, String imageUrl) {
+        this.code = code;
+        this.name = name;
+        this.basic = basic;
+        this.imageUrl = imageUrl;
+    }
+}

--- a/src/main/java/com/swyp/server/domain/sticker/entity/UserSticker.java
+++ b/src/main/java/com/swyp/server/domain/sticker/entity/UserSticker.java
@@ -1,0 +1,48 @@
+package com.swyp.server.domain.sticker.entity;
+
+import com.swyp.server.domain.user.entity.User;
+import com.swyp.server.global.SoftDeletableEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+        name = "user_stickers",
+        uniqueConstraints = {
+            @UniqueConstraint(
+                    name = "uk_user_sticker_user_id_sticker_id",
+                    columnNames = {"user_id", "sticker_id"})
+        })
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserSticker extends SoftDeletableEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "sticker_id", nullable = false)
+    private Sticker sticker;
+
+    @Builder
+    public UserSticker(User user, Sticker sticker) {
+        this.user = user;
+        this.sticker = sticker;
+    }
+}

--- a/src/main/java/com/swyp/server/domain/sticker/entity/UserSticker.java
+++ b/src/main/java/com/swyp/server/domain/sticker/entity/UserSticker.java
@@ -1,7 +1,7 @@
 package com.swyp.server.domain.sticker.entity;
 
 import com.swyp.server.domain.user.entity.User;
-import com.swyp.server.global.SoftDeletableEntity;
+import com.swyp.server.global.AuditableEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -26,7 +26,7 @@ import lombok.NoArgsConstructor;
         })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class UserSticker extends SoftDeletableEntity {
+public class UserSticker extends AuditableEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/swyp/server/domain/sticker/entity/UserStickerProgress.java
+++ b/src/main/java/com/swyp/server/domain/sticker/entity/UserStickerProgress.java
@@ -1,0 +1,42 @@
+package com.swyp.server.domain.sticker.entity;
+
+import com.swyp.server.domain.user.entity.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "user_sticker_progress")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserStickerProgress {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private User user;
+
+    private int lastConfirmedCompletedDateCount;
+
+    @Builder
+    public UserStickerProgress(User user, int lastConfirmedCompletedDateCount) {
+        this.user = user;
+        this.lastConfirmedCompletedDateCount = lastConfirmedCompletedDateCount;
+    }
+
+    public void confirmBoard(int completedDateCount) {
+        this.lastConfirmedCompletedDateCount = completedDateCount;
+    }
+}

--- a/src/main/java/com/swyp/server/domain/sticker/repository/StickerRepository.java
+++ b/src/main/java/com/swyp/server/domain/sticker/repository/StickerRepository.java
@@ -1,0 +1,13 @@
+package com.swyp.server.domain.sticker.repository;
+
+import com.swyp.server.domain.sticker.entity.Sticker;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StickerRepository extends JpaRepository<Sticker, Long> {
+
+    Optional<Sticker> findByCode(String code);
+
+    List<Sticker> findAllByBasicTrue();
+}

--- a/src/main/java/com/swyp/server/domain/sticker/repository/UserStickerProgressRepository.java
+++ b/src/main/java/com/swyp/server/domain/sticker/repository/UserStickerProgressRepository.java
@@ -1,0 +1,10 @@
+package com.swyp.server.domain.sticker.repository;
+
+import com.swyp.server.domain.sticker.entity.UserStickerProgress;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserStickerProgressRepository extends JpaRepository<UserStickerProgress, Long> {
+
+    Optional<UserStickerProgress> findByUserId(Long userId);
+}

--- a/src/main/java/com/swyp/server/domain/sticker/repository/UserStickerRepository.java
+++ b/src/main/java/com/swyp/server/domain/sticker/repository/UserStickerRepository.java
@@ -8,4 +8,6 @@ public interface UserStickerRepository extends JpaRepository<UserSticker, Long> 
     List<UserSticker> findAllByUserId(Long userId);
 
     boolean existsByUserIdAndStickerId(Long userId, Long stickerId);
+
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/com/swyp/server/domain/sticker/repository/UserStickerRepository.java
+++ b/src/main/java/com/swyp/server/domain/sticker/repository/UserStickerRepository.java
@@ -1,0 +1,11 @@
+package com.swyp.server.domain.sticker.repository;
+
+import com.swyp.server.domain.sticker.entity.UserSticker;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserStickerRepository extends JpaRepository<UserSticker, Long> {
+    List<UserSticker> findAllByUserId(Long userId);
+
+    boolean existsByUserIdAndStickerId(Long userId, Long stickerId);
+}

--- a/src/main/java/com/swyp/server/domain/sticker/service/StickerQueryService.java
+++ b/src/main/java/com/swyp/server/domain/sticker/service/StickerQueryService.java
@@ -1,7 +1,10 @@
 package com.swyp.server.domain.sticker.service;
 
-import com.swyp.server.domain.sticker.dto.CompletedDateStickerResponse;
+import com.swyp.server.domain.sticker.dto.DateStickerResponse;
+import com.swyp.server.domain.sticker.dto.StickerBoardResponse;
 import com.swyp.server.domain.sticker.dto.WeeklyStickerResponse;
+import com.swyp.server.domain.sticker.entity.UserStickerProgress;
+import com.swyp.server.domain.sticker.repository.UserStickerProgressRepository;
 import com.swyp.server.domain.todo.service.TodoService;
 import com.swyp.server.global.util.DateUtils;
 import java.time.LocalDate;
@@ -15,27 +18,68 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class StickerQueryService {
 
-    // 초기 개발 단계에서는 DEFAULT 스티커 하나로 고정하였음
+    // 초기 개발 단계에서는 DEFAULT 스티커 하나, 보드판의 크기는 30으로 고정하였음
     private static final String DEFAULT_STICKER_CODE = "BASIC_STICKER";
+    private static final int BOARD_SIZE = 30;
 
     private final TodoService todoService;
+    private final UserStickerProgressRepository progressRepository;
 
     public WeeklyStickerResponse getWeeklyStickers(Long userId, LocalDate today) {
         LocalDate startDate = DateUtils.getWeekStart(today);
         LocalDate endDate = DateUtils.getWeekEnd(today);
         List<LocalDate> completedDates = todoService.getCompletedDates(userId, startDate, endDate);
 
-        List<CompletedDateStickerResponse> stickers =
-                completedDates.stream()
-                        .map(date -> new CompletedDateStickerResponse(date, DEFAULT_STICKER_CODE))
+        List<DateStickerResponse> stickers =
+                startDate
+                        .datesUntil(endDate.plusDays(1))
+                        .map(
+                                date -> {
+                                    String stickerCode = null;
+
+                                    if (completedDates.contains(date)) {
+                                        stickerCode = DEFAULT_STICKER_CODE;
+                                    }
+                                    return new DateStickerResponse(date, stickerCode);
+                                })
                         .toList();
 
         return new WeeklyStickerResponse(createWeekLabel(today), startDate, endDate, stickers);
     }
 
+    public StickerBoardResponse getStickerBoard(Long userId) {
+        int totalCompleted = todoService.countCompletedDates(userId);
+
+        int confirmedCount =
+                progressRepository
+                        .findByUserId(userId)
+                        .map(UserStickerProgress::getLastConfirmedCompletedDateCount)
+                        .orElse(0);
+
+        int progressCount = Math.max(totalCompleted - confirmedCount, 0);
+
+        int filledSlots = calculateFilledSlots(progressCount);
+        boolean showPopup = shouldShowPopup(progressCount);
+
+        return new StickerBoardResponse(BOARD_SIZE, filledSlots, showPopup);
+    }
+
+    private int calculateFilledSlots(int progressCount) {
+        if (progressCount == 0) {
+            return 0;
+        }
+
+        int remain = progressCount % BOARD_SIZE;
+        return remain == 0 ? BOARD_SIZE : remain;
+    }
+
+    private boolean shouldShowPopup(int progressCount) {
+        return progressCount > 0 && progressCount % BOARD_SIZE == 0;
+    }
+
     private String createWeekLabel(LocalDate today) {
         int month = today.getMonthValue();
-        int weekOfMonth = (today.getDayOfMonth() / -1) / 7 + 1;
+        int weekOfMonth = (today.getDayOfMonth() - 1) / 7 + 1;
         return month + "월 " + weekOfMonth + "주차";
     }
 }

--- a/src/main/java/com/swyp/server/domain/sticker/service/StickerQueryService.java
+++ b/src/main/java/com/swyp/server/domain/sticker/service/StickerQueryService.java
@@ -56,25 +56,27 @@ public class StickerQueryService {
                         .map(UserStickerProgress::getLastConfirmedCompletedDateCount)
                         .orElse(0);
 
-        int progressCount = Math.max(totalCompleted - confirmedCount, 0);
+        int filledSlots = calculateFilledSlots(totalCompleted);
 
-        int filledSlots = calculateFilledSlots(progressCount);
-        boolean showPopup = shouldShowPopup(progressCount);
+        int currentBoard = totalCompleted / BOARD_SIZE;
+        int confirmedBoard = confirmedCount / BOARD_SIZE;
+        boolean showPopup = shouldShowPopup(filledSlots, currentBoard, confirmedBoard);
 
         return new StickerBoardResponse(BOARD_SIZE, filledSlots, showPopup);
     }
 
-    private int calculateFilledSlots(int progressCount) {
-        if (progressCount == 0) {
+    private int calculateFilledSlots(int totalCompleted) {
+        if (totalCompleted == 0) {
             return 0;
         }
 
-        int remain = progressCount % BOARD_SIZE;
+        int remain = totalCompleted % BOARD_SIZE;
         return remain == 0 ? BOARD_SIZE : remain;
     }
 
-    private boolean shouldShowPopup(int progressCount) {
-        return progressCount > 0 && progressCount % BOARD_SIZE == 0;
+    private boolean shouldShowPopup(int filledSlots, int currentBoard, int confirmedBoard) {
+
+        return filledSlots == BOARD_SIZE && currentBoard > confirmedBoard;
     }
 
     private String createWeekLabel(LocalDate today) {

--- a/src/main/java/com/swyp/server/domain/sticker/service/StickerQueryService.java
+++ b/src/main/java/com/swyp/server/domain/sticker/service/StickerQueryService.java
@@ -1,0 +1,41 @@
+package com.swyp.server.domain.sticker.service;
+
+import com.swyp.server.domain.sticker.dto.CompletedDateStickerResponse;
+import com.swyp.server.domain.sticker.dto.WeeklyStickerResponse;
+import com.swyp.server.domain.todo.service.TodoService;
+import com.swyp.server.global.util.DateUtils;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StickerQueryService {
+
+    // 초기 개발 단계에서는 DEFAULT 스티커 하나로 고정하였음
+    private static final String DEFAULT_STICKER_CODE = "BASIC_STICKER";
+
+    private final TodoService todoService;
+
+    public WeeklyStickerResponse getWeeklyStickers(Long userId, LocalDate today) {
+        LocalDate startDate = DateUtils.getWeekStart(today);
+        LocalDate endDate = DateUtils.getWeekEnd(today);
+        List<LocalDate> completedDates = todoService.getCompletedDates(userId, startDate, endDate);
+
+        List<CompletedDateStickerResponse> stickers =
+                completedDates.stream()
+                        .map(date -> new CompletedDateStickerResponse(date, DEFAULT_STICKER_CODE))
+                        .toList();
+
+        return new WeeklyStickerResponse(createWeekLabel(today), startDate, endDate, stickers);
+    }
+
+    private String createWeekLabel(LocalDate today) {
+        int month = today.getMonthValue();
+        int weekOfMonth = (today.getDayOfMonth() / -1) / 7 + 1;
+        return month + "월 " + weekOfMonth + "주차";
+    }
+}

--- a/src/main/java/com/swyp/server/domain/sticker/service/StickerService.java
+++ b/src/main/java/com/swyp/server/domain/sticker/service/StickerService.java
@@ -1,0 +1,39 @@
+package com.swyp.server.domain.sticker.service;
+
+import com.swyp.server.domain.sticker.entity.UserStickerProgress;
+import com.swyp.server.domain.sticker.repository.UserStickerProgressRepository;
+import com.swyp.server.domain.todo.service.TodoService;
+import com.swyp.server.domain.user.entity.User;
+import com.swyp.server.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class StickerService {
+
+    private final TodoService todoService;
+    private final UserRepository userRepository;
+    private final UserStickerProgressRepository progressRepository;
+
+    public void confirmStickerBoard(Long userId) {
+        int totalCompleted = todoService.countCompletedDates(userId);
+
+        UserStickerProgress progress =
+                progressRepository.findByUserId(userId).orElseGet(() -> createProgress(userId));
+
+        progress.confirmBoard(totalCompleted);
+    }
+
+    private UserStickerProgress createProgress(Long userId) {
+        User user = userRepository.getReferenceById(userId);
+
+        return progressRepository.save(
+                UserStickerProgress.builder()
+                        .user(user)
+                        .lastConfirmedCompletedDateCount(0)
+                        .build());
+    }
+}

--- a/src/main/java/com/swyp/server/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/com/swyp/server/domain/todo/repository/TodoRepository.java
@@ -16,6 +16,9 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
 
     Optional<Todo> findByIdAndUserId(Long todoId, Long userId);
 
+    List<Todo> findAllByUserIdAndTodoDateBetween(
+            Long userId, LocalDate startDate, LocalDate endDate);
+
     @Modifying
     @Query(value = "DELETE FROM todos WHERE user_id = :userId", nativeQuery = true)
     void hardDeleteAllByUserId(@Param("userId") Long userId);

--- a/src/main/java/com/swyp/server/domain/todo/service/TodoService.java
+++ b/src/main/java/com/swyp/server/domain/todo/service/TodoService.java
@@ -113,4 +113,11 @@ public class TodoService {
                 .sorted()
                 .toList();
     }
+
+    @Transactional(readOnly = true)
+    public int countCompletedDates(Long userId) {
+        LocalDate startDate = LocalDate.MIN;
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        return getCompletedDates(userId, startDate, today).size();
+    }
 }

--- a/src/main/java/com/swyp/server/domain/todo/service/TodoService.java
+++ b/src/main/java/com/swyp/server/domain/todo/service/TodoService.java
@@ -8,6 +8,7 @@ import com.swyp.server.domain.user.entity.User;
 import com.swyp.server.domain.user.repository.UserRepository;
 import com.swyp.server.global.exception.CustomException;
 import com.swyp.server.global.exception.ErrorCode;
+import com.swyp.server.global.util.DateUtils;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;
@@ -116,7 +117,12 @@ public class TodoService {
 
     @Transactional(readOnly = true)
     public int countCompletedDates(Long userId) {
-        LocalDate startDate = LocalDate.MIN;
+        LocalDate startDate =
+                userRepository
+                        .findById(userId)
+                        .map(user -> user.getCreatedAt().toLocalDate())
+                        .orElse(DateUtils.APPLICATION_LAUNCH_DATE);
+
         LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
         return getCompletedDates(userId, startDate, today).size();
     }

--- a/src/main/java/com/swyp/server/domain/todo/service/TodoService.java
+++ b/src/main/java/com/swyp/server/domain/todo/service/TodoService.java
@@ -8,9 +8,12 @@ import com.swyp.server.domain.user.entity.User;
 import com.swyp.server.domain.user.repository.UserRepository;
 import com.swyp.server.global.exception.CustomException;
 import com.swyp.server.global.exception.ErrorCode;
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -95,5 +98,35 @@ public class TodoService {
         LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
         return todoRepository.findAllByUserIdAndTodoDateOrderByCompletedAscCreatedAtAsc(
                 userId, today);
+    }
+
+    @Transactional(readOnly = true)
+    public List<LocalDate> getWeeklyCompletedDates(Long userId, LocalDate today) {
+        LocalDate startDate = getWeekStart(today);
+        LocalDate endDate = getWeekEnd(today);
+        return getCompletedDates(userId, startDate, endDate);
+    }
+
+    @Transactional(readOnly = true)
+    public List<LocalDate> getCompletedDates(Long userId, LocalDate startDate, LocalDate endDate) {
+        List<Todo> todos =
+                todoRepository.findAllByUserIdAndTodoDateBetween(userId, startDate, endDate);
+
+        Map<LocalDate, List<Todo>> groupedByDate =
+                todos.stream().collect(Collectors.groupingBy(Todo::getTodoDate));
+
+        return groupedByDate.entrySet().stream()
+                .filter(entry -> entry.getValue().stream().allMatch(Todo::isCompleted))
+                .map(Map.Entry::getKey)
+                .sorted()
+                .toList();
+    }
+
+    private LocalDate getWeekStart(LocalDate today) {
+        return today.with(DayOfWeek.MONDAY);
+    }
+
+    private LocalDate getWeekEnd(LocalDate today) {
+        return getWeekStart(today).plusDays(6);
     }
 }

--- a/src/main/java/com/swyp/server/domain/todo/service/TodoService.java
+++ b/src/main/java/com/swyp/server/domain/todo/service/TodoService.java
@@ -8,7 +8,6 @@ import com.swyp.server.domain.user.entity.User;
 import com.swyp.server.domain.user.repository.UserRepository;
 import com.swyp.server.global.exception.CustomException;
 import com.swyp.server.global.exception.ErrorCode;
-import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;
@@ -101,13 +100,6 @@ public class TodoService {
     }
 
     @Transactional(readOnly = true)
-    public List<LocalDate> getWeeklyCompletedDates(Long userId, LocalDate today) {
-        LocalDate startDate = getWeekStart(today);
-        LocalDate endDate = getWeekEnd(today);
-        return getCompletedDates(userId, startDate, endDate);
-    }
-
-    @Transactional(readOnly = true)
     public List<LocalDate> getCompletedDates(Long userId, LocalDate startDate, LocalDate endDate) {
         List<Todo> todos =
                 todoRepository.findAllByUserIdAndTodoDateBetween(userId, startDate, endDate);
@@ -120,13 +112,5 @@ public class TodoService {
                 .map(Map.Entry::getKey)
                 .sorted()
                 .toList();
-    }
-
-    private LocalDate getWeekStart(LocalDate today) {
-        return today.with(DayOfWeek.MONDAY);
-    }
-
-    private LocalDate getWeekEnd(LocalDate today) {
-        return getWeekStart(today).plusDays(6);
     }
 }

--- a/src/main/java/com/swyp/server/domain/user/service/UserWithdrawalScheduler.java
+++ b/src/main/java/com/swyp/server/domain/user/service/UserWithdrawalScheduler.java
@@ -1,5 +1,6 @@
 package com.swyp.server.domain.user.service;
 
+import com.swyp.server.domain.sticker.repository.UserStickerRepository;
 import com.swyp.server.domain.todo.repository.TodoRepository;
 import com.swyp.server.domain.user.entity.User;
 import com.swyp.server.domain.user.repository.UserRepository;
@@ -21,6 +22,7 @@ public class UserWithdrawalScheduler {
     private final UserRepository userRepository;
     private final FcmTokenRepository fcmTokenRepository;
     private final TodoRepository todoRepository;
+    private final UserStickerRepository userStickerRepository;
 
     @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
     @Transactional
@@ -34,6 +36,7 @@ public class UserWithdrawalScheduler {
 
         deletedUsers.forEach(user -> fcmTokenRepository.deleteByUserId(user.getId()));
         deletedUsers.forEach(user -> todoRepository.hardDeleteAllByUserId(user.getId()));
+        deletedUsers.forEach(user -> userStickerRepository.deleteAllByUserId(user.getId()));
 
         userRepository.deleteAll(deletedUsers);
         log.info("Hard deleted {} withdrawn users", deletedUsers.size());

--- a/src/main/java/com/swyp/server/global/util/DateUtils.java
+++ b/src/main/java/com/swyp/server/global/util/DateUtils.java
@@ -1,0 +1,15 @@
+package com.swyp.server.global.util;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+
+public final class DateUtils {
+
+    public static LocalDate getWeekStart(LocalDate today) {
+        return today.with(DayOfWeek.MONDAY);
+    }
+
+    public static LocalDate getWeekEnd(LocalDate today) {
+        return getWeekStart(today).plusDays(6);
+    }
+}

--- a/src/main/java/com/swyp/server/global/util/DateUtils.java
+++ b/src/main/java/com/swyp/server/global/util/DateUtils.java
@@ -2,8 +2,13 @@ package com.swyp.server.global.util;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class DateUtils {
+
+    public static final LocalDate APPLICATION_LAUNCH_DATE = LocalDate.of(2026, 3, 1);
 
     public static LocalDate getWeekStart(LocalDate today) {
         return today.with(DayOfWeek.MONDAY);


### PR DESCRIPTION
## 📌 관련 이슈
- close #46 

## ✨ 변경 사항
- Sticker, UserSticker ,UserStickerProgress 엔티티 설계
- Todo 완료 날짜 기반 스티커 계산 로직 구현
- 메인 화면 주간 스티커 조회 API 구현
- 스티커판 조회 API 구현
- 스티커판 완료 확인 API 구현
- 날짜 계산 유틸 추가

## 📸 테스트 증명 (필수)
- 주간 스티커 조회 API 응답 확인
   - 완료한 날짜에만 stickerCode 반환
- 스티커판 조회 API 응답 확인    
- 스티커판 완료 팝업 테스트
   - 로컬 DB에 데이터 추가하여 정상 동작 확인

## 📚 리뷰어 참고 사항
- 현재는 기본 스티커를 1개, 스티커 보드판의 크기를 30칸으로 고정해두었습니다.
- 스티커는 URL아 아닌 앱 로컬 리소스 매핑으로 구현하였습니다.

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요?
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?
- [x] spotlessApply 실행했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a sticker collection system rewarding users for completing tasks
  * View weekly sticker progress with per-date completion and sticker details
  * Sticker board view showing board size, filled slots, and completion popup prompts
  * Ability to confirm sticker board completion to update progress
  * Basic sticker catalog (codes, names, images) available for collection and display
<!-- end of auto-generated comment: release notes by coderabbit.ai -->