### PR TITLE
[Feat/#51] 부모/자녀 역할별 Todo 카테고리 분리

### DIFF
--- a/src/main/java/com/swyp/server/domain/todo/controller/TodoController.java
+++ b/src/main/java/com/swyp/server/domain/todo/controller/TodoController.java
@@ -1,11 +1,15 @@
 package com.swyp.server.domain.todo.controller;
 
+import com.swyp.server.domain.todo.dto.TodoCategoryListResponse;
 import com.swyp.server.domain.todo.dto.TodoCreateRequest;
 import com.swyp.server.domain.todo.dto.TodoCreateResponse;
 import com.swyp.server.domain.todo.dto.TodoListResponse;
 import com.swyp.server.domain.todo.dto.TodoUpdateRequest;
 import com.swyp.server.domain.todo.entity.Todo;
+import com.swyp.server.domain.todo.entity.TodoCategory;
 import com.swyp.server.domain.todo.service.TodoService;
+import com.swyp.server.domain.user.entity.User;
+import com.swyp.server.domain.user.service.UserService;
 import com.swyp.server.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -31,6 +35,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class TodoController {
 
     private final TodoService todoService;
+    private final UserService userService;
 
     @Operation(summary = "할 일 생성")
     @PostMapping
@@ -76,5 +81,15 @@ public class TodoController {
         todoService.deleteTodo(userId, todoId);
 
         return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
+    @Operation(summary = "할 일 카테고리 조회")
+    @GetMapping("/categories")
+    public ResponseEntity<ApiResponse<?>> getCategories(@AuthenticationPrincipal Long userId) {
+
+        User user = userService.findById(userId);
+        List<TodoCategory> categories = todoService.getCategories(user.getUserType());
+
+        return ResponseEntity.ok(ApiResponse.success(TodoCategoryListResponse.from(categories)));
     }
 }

--- a/src/main/java/com/swyp/server/domain/todo/controller/TodoController.java
+++ b/src/main/java/com/swyp/server/domain/todo/controller/TodoController.java
@@ -85,7 +85,8 @@ public class TodoController {
 
     @Operation(summary = "할 일 카테고리 조회")
     @GetMapping("/categories")
-    public ResponseEntity<ApiResponse<?>> getCategories(@AuthenticationPrincipal Long userId) {
+    public ResponseEntity<ApiResponse<TodoCategoryListResponse>> getCategories(
+            @AuthenticationPrincipal Long userId) {
 
         User user = userService.findById(userId);
         List<TodoCategory> categories = todoService.getCategories(user.getUserType());

--- a/src/main/java/com/swyp/server/domain/todo/dto/TodoCategoryListResponse.java
+++ b/src/main/java/com/swyp/server/domain/todo/dto/TodoCategoryListResponse.java
@@ -1,0 +1,12 @@
+package com.swyp.server.domain.todo.dto;
+
+import com.swyp.server.domain.todo.entity.TodoCategory;
+import java.util.List;
+
+public record TodoCategoryListResponse(List<TodoCategoryResponse> categories) {
+
+    public static TodoCategoryListResponse from(List<TodoCategory> categories) {
+        return new TodoCategoryListResponse(
+                categories.stream().map(TodoCategoryResponse::from).toList());
+    }
+}

--- a/src/main/java/com/swyp/server/domain/todo/dto/TodoCategoryResponse.java
+++ b/src/main/java/com/swyp/server/domain/todo/dto/TodoCategoryResponse.java
@@ -1,0 +1,10 @@
+package com.swyp.server.domain.todo.dto;
+
+import com.swyp.server.domain.todo.entity.TodoCategory;
+
+public record TodoCategoryResponse(String name, String label) {
+
+    public static TodoCategoryResponse from(TodoCategory todoCategory) {
+        return new TodoCategoryResponse(todoCategory.name(), todoCategory.getLabel());
+    }
+}

--- a/src/main/java/com/swyp/server/domain/todo/entity/TodoCategory.java
+++ b/src/main/java/com/swyp/server/domain/todo/entity/TodoCategory.java
@@ -23,6 +23,9 @@ public enum TodoCategory {
     private final Set<UserType> allowedUserTypes;
 
     public boolean isAllowed(UserType userType) {
+        if (userType == null) {
+            return false;
+        }
         return allowedUserTypes.contains(userType);
     }
 }

--- a/src/main/java/com/swyp/server/domain/todo/entity/TodoCategory.java
+++ b/src/main/java/com/swyp/server/domain/todo/entity/TodoCategory.java
@@ -1,18 +1,28 @@
 package com.swyp.server.domain.todo.entity;
 
+import com.swyp.server.domain.user.entity.UserType;
+import java.util.Set;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
 public enum TodoCategory {
-    STUDY("공부"),
-    HOMEWORK("숙제"),
-    EXERCISE("운동"),
-    CLEANING("정리"),
-    READING("독서"),
-    HOUSEWORK("집안일"),
-    CREATIVE_ACTIVITY("창의활동");
+    STUDY("공부", Set.of(UserType.CHILD)),
+    HOMEWORK("숙제", Set.of(UserType.CHILD)),
+    EXERCISE("운동", Set.of(UserType.CHILD, UserType.PARENT)),
+    CLEANING("정리", Set.of(UserType.CHILD, UserType.PARENT)),
+    READING("독서", Set.of(UserType.CHILD, UserType.PARENT)),
+    HOUSEWORK("집안일", Set.of(UserType.CHILD, UserType.PARENT)),
+    CREATIVE_ACTIVITY("창의활동", Set.of(UserType.CHILD)),
+    WORK("업무", Set.of(UserType.PARENT)),
+    APPOINTMENT("약속", Set.of(UserType.PARENT)),
+    PARENTING("육아", Set.of(UserType.PARENT));
 
     private final String label;
+    private final Set<UserType> allowedUserTypes;
+
+    public boolean isAllowed(UserType userType) {
+        return allowedUserTypes.contains(userType);
+    }
 }

--- a/src/main/java/com/swyp/server/domain/todo/service/TodoService.java
+++ b/src/main/java/com/swyp/server/domain/todo/service/TodoService.java
@@ -5,6 +5,7 @@ import com.swyp.server.domain.todo.entity.TodoCategory;
 import com.swyp.server.domain.todo.entity.TodoColor;
 import com.swyp.server.domain.todo.repository.TodoRepository;
 import com.swyp.server.domain.user.entity.User;
+import com.swyp.server.domain.user.entity.UserType;
 import com.swyp.server.domain.user.repository.UserRepository;
 import com.swyp.server.global.exception.CustomException;
 import com.swyp.server.global.exception.ErrorCode;
@@ -33,6 +34,8 @@ public class TodoService {
                 userRepository
                         .findById(userId)
                         .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        validateCategory(user.getUserType(), category);
 
         Todo todo =
                 Todo.builder()
@@ -67,6 +70,7 @@ public class TodoService {
         }
 
         if (category != null) {
+            validateCategory(todo.getUser().getUserType(), category);
             todo.updateCategory(category);
         }
 
@@ -125,5 +129,11 @@ public class TodoService {
 
         LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
         return getCompletedDates(userId, startDate, today).size();
+    }
+
+    private void validateCategory(UserType userType, TodoCategory category) {
+        if (!category.isAllowed(userType)) {
+            throw new CustomException(ErrorCode.TODO_CATEGORY_INVALID);
+        }
     }
 }

--- a/src/main/java/com/swyp/server/domain/todo/service/TodoService.java
+++ b/src/main/java/com/swyp/server/domain/todo/service/TodoService.java
@@ -134,13 +134,18 @@ public class TodoService {
 
     @Transactional(readOnly = true)
     public List<TodoCategory> getCategories(UserType userType) {
+
+        if (userType == null) {
+            throw new CustomException(ErrorCode.USER_TYPE_REQUIRED);
+        }
+
         return Arrays.stream(TodoCategory.values())
                 .filter(category -> category.isAllowed(userType))
                 .toList();
     }
 
     private void validateCategory(UserType userType, TodoCategory category) {
-        if (!category.isAllowed(userType)) {
+        if (category == null || !category.isAllowed(userType)) {
             throw new CustomException(ErrorCode.TODO_CATEGORY_INVALID);
         }
     }

--- a/src/main/java/com/swyp/server/domain/todo/service/TodoService.java
+++ b/src/main/java/com/swyp/server/domain/todo/service/TodoService.java
@@ -145,6 +145,10 @@ public class TodoService {
     }
 
     private void validateCategory(UserType userType, TodoCategory category) {
+        if (userType == null) {
+            throw new CustomException(ErrorCode.USER_TYPE_REQUIRED);
+        }
+
         if (category == null || !category.isAllowed(userType)) {
             throw new CustomException(ErrorCode.TODO_CATEGORY_INVALID);
         }

--- a/src/main/java/com/swyp/server/domain/todo/service/TodoService.java
+++ b/src/main/java/com/swyp/server/domain/todo/service/TodoService.java
@@ -12,6 +12,7 @@ import com.swyp.server.global.exception.ErrorCode;
 import com.swyp.server.global.util.DateUtils;
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -129,6 +130,13 @@ public class TodoService {
 
         LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
         return getCompletedDates(userId, startDate, today).size();
+    }
+
+    @Transactional(readOnly = true)
+    public List<TodoCategory> getCategories(UserType userType) {
+        return Arrays.stream(TodoCategory.values())
+                .filter(category -> category.isAllowed(userType))
+                .toList();
     }
 
     private void validateCategory(UserType userType, TodoCategory category) {

--- a/src/main/java/com/swyp/server/global/exception/ErrorCode.java
+++ b/src/main/java/com/swyp/server/global/exception/ErrorCode.java
@@ -45,6 +45,7 @@ public enum ErrorCode {
     TODO_TITLE_REQUIRED(40009, 400, "할 일 제목은 필수입니다."),
     TODO_CATEGORY_REQUIRED(40011, 400, "할 일 카테고리는 필수입니다."),
     TODO_COLOR_REQUIRED(40013, 400, "할 일 색상은 필수입니다."),
+    TODO_CATEGORY_INVALID(40018, 400, "유효하지 않은 할 일 카테고리 입니다."),
 
     // Schedule
     SCHEDULE_NOT_FOUND(40403, 404, "일정을 찾을 수 없습니다."),


### PR DESCRIPTION
## 📌 관련 이슈
- close #51

## ✨ 변경 사항
- Todo 생성 시 역할에 맞지 않는 카테고리 선택 불가
- 역할별 카테고리 목록 조회
- 잘못된 카테고리 선택 시 예외 처리

## 📸 테스트 증명 (필수)
<img width="500" height="558" alt="스크린샷 2026-03-18 오후 2 44 43" src="https://github.com/user-attachments/assets/60627035-106b-4dc9-940b-1133697762c0" />

조회 및 역할에 맞지 않는 카테고리 입력 시 예외 처리 했습니다.

## 📚 리뷰어 참고 사항
- 

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요?
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?
- [x] spotlessApply 실행했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New endpoint to fetch personalized todo categories tailored to each user type

* **Improvements**
  * Categories are automatically filtered and curated per user role
  * Category selection is now validated on create/update with clearer error responses for invalid choices
<!-- end of auto-generated comment: release notes by coderabbit.ai -->