### PR TITLE
[Feat#58] 주간 스티커 주차 이동 조회 기능 추가

### DIFF
--- a/src/main/java/com/swyp/server/domain/sticker/controller/StickerController.java
+++ b/src/main/java/com/swyp/server/domain/sticker/controller/StickerController.java
@@ -15,6 +15,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Sticker", description = "스티커 API")
@@ -29,9 +30,12 @@ public class StickerController {
     @Operation(summary = "주간 스티커 조회")
     @GetMapping("/weekly")
     public ResponseEntity<ApiResponse<WeeklyStickerResponse>> getWeeklyStickers(
-            @AuthenticationPrincipal Long userId) {
+            @AuthenticationPrincipal Long userId,
+            @RequestParam(defaultValue = "0") int weekOffset) {
+
         LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
-        WeeklyStickerResponse response = stickerQueryService.getWeeklyStickers(userId, today);
+        WeeklyStickerResponse response =
+                stickerQueryService.getWeeklyStickers(userId, today, weekOffset);
 
         return ResponseEntity.ok(ApiResponse.success(response));
     }

--- a/src/main/java/com/swyp/server/domain/sticker/dto/WeeklyStickerResponse.java
+++ b/src/main/java/com/swyp/server/domain/sticker/dto/WeeklyStickerResponse.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 public record WeeklyStickerResponse(
         String weekLabel,
+        int weekOffset,
         LocalDate startDate,
         LocalDate endDate,
         List<DateStickerResponse> stickers) {}

--- a/src/main/java/com/swyp/server/domain/sticker/service/StickerQueryService.java
+++ b/src/main/java/com/swyp/server/domain/sticker/service/StickerQueryService.java
@@ -6,6 +6,8 @@ import com.swyp.server.domain.sticker.dto.WeeklyStickerResponse;
 import com.swyp.server.domain.sticker.entity.UserStickerProgress;
 import com.swyp.server.domain.sticker.repository.UserStickerProgressRepository;
 import com.swyp.server.domain.todo.service.TodoService;
+import com.swyp.server.global.exception.CustomException;
+import com.swyp.server.global.exception.ErrorCode;
 import com.swyp.server.global.util.DateUtils;
 import java.time.LocalDate;
 import java.util.List;
@@ -21,11 +23,14 @@ public class StickerQueryService {
     // 초기 개발 단계에서는 DEFAULT 스티커 하나, 보드판의 크기는 30으로 고정하였음
     private static final String DEFAULT_STICKER_CODE = "BASIC_STICKER";
     private static final int BOARD_SIZE = 30;
+    private static final int MIN_WEEK_OFFSET = -52;
+    private static final int MAX_WEEK_OFFSET = 52;
 
     private final TodoService todoService;
     private final UserStickerProgressRepository progressRepository;
 
     public WeeklyStickerResponse getWeeklyStickers(Long userId, LocalDate today, int weekOffset) {
+        validateWeekOffset(weekOffset);
         LocalDate targetDate = today.plusWeeks(weekOffset);
 
         LocalDate startDate = DateUtils.getWeekStart(targetDate);
@@ -86,5 +91,11 @@ public class StickerQueryService {
         int month = targetDate.getMonthValue();
         int weekOfMonth = (targetDate.getDayOfMonth() - 1) / 7 + 1;
         return month + "월 " + weekOfMonth + "주차";
+    }
+
+    private void validateWeekOffset(int weekOffset) {
+        if (weekOffset < MIN_WEEK_OFFSET || weekOffset > MAX_WEEK_OFFSET) {
+            throw new CustomException(ErrorCode.WEEK_OFFSET_INVALID);
+        }
     }
 }

--- a/src/main/java/com/swyp/server/domain/sticker/service/StickerQueryService.java
+++ b/src/main/java/com/swyp/server/domain/sticker/service/StickerQueryService.java
@@ -25,9 +25,11 @@ public class StickerQueryService {
     private final TodoService todoService;
     private final UserStickerProgressRepository progressRepository;
 
-    public WeeklyStickerResponse getWeeklyStickers(Long userId, LocalDate today) {
-        LocalDate startDate = DateUtils.getWeekStart(today);
-        LocalDate endDate = DateUtils.getWeekEnd(today);
+    public WeeklyStickerResponse getWeeklyStickers(Long userId, LocalDate today, int weekOffset) {
+        LocalDate targetDate = today.plusWeeks(weekOffset);
+
+        LocalDate startDate = DateUtils.getWeekStart(targetDate);
+        LocalDate endDate = DateUtils.getWeekEnd(targetDate);
         List<LocalDate> completedDates = todoService.getCompletedDates(userId, startDate, endDate);
 
         List<DateStickerResponse> stickers =
@@ -44,7 +46,8 @@ public class StickerQueryService {
                                 })
                         .toList();
 
-        return new WeeklyStickerResponse(createWeekLabel(today), startDate, endDate, stickers);
+        return new WeeklyStickerResponse(
+                createWeekLabel(targetDate), weekOffset, startDate, endDate, stickers);
     }
 
     public StickerBoardResponse getStickerBoard(Long userId) {
@@ -79,9 +82,9 @@ public class StickerQueryService {
         return filledSlots == BOARD_SIZE && currentBoard > confirmedBoard;
     }
 
-    private String createWeekLabel(LocalDate today) {
-        int month = today.getMonthValue();
-        int weekOfMonth = (today.getDayOfMonth() - 1) / 7 + 1;
+    private String createWeekLabel(LocalDate targetDate) {
+        int month = targetDate.getMonthValue();
+        int weekOfMonth = (targetDate.getDayOfMonth() - 1) / 7 + 1;
         return month + "월 " + weekOfMonth + "주차";
     }
 }

--- a/src/main/java/com/swyp/server/global/exception/ErrorCode.java
+++ b/src/main/java/com/swyp/server/global/exception/ErrorCode.java
@@ -69,7 +69,8 @@ public enum ErrorCode {
     HABIT_REWARD_REQUIRED(40022, 400, "습관 보상 설정은 필수입니다."),
     HABIT_COMPLETED_REQUIRED(40023, 400, "습관 완료 여부는 필수입니다."),
 
-    INVITE_CODE_REQUIRED(40015, 400, "초대 코드는 필수입니다.");
+    INVITE_CODE_REQUIRED(40015, 400, "초대 코드는 필수입니다."),
+    WEEK_OFFSET_INVALID(40024, 400, "weekOffset은 -52 이상 52 이하여야 합니다.");
 
     private final int code;
     private final int status;


### PR DESCRIPTION
## 📌 관련 이슈
- close #58 

## ✨ 변경 사항
- 주간 스티커 조회 API 에 weekOffset 파라미터 추가
- 서버 시간 기준 주차 이동 조회 로직
- 응답에 weekOffset 필드 추가

## 📸 테스트 증명 (필수)
<img width="513" height="585" alt="스크린샷 2026-03-19 오후 10 00 18" src="https://github.com/user-attachments/assets/8d19c932-37a5-4b1a-8bab-2a24b810cea9" />

## 📚 리뷰어 참고 사항
- 

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요?
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?
- [x] spotlessApply 실행했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added weekOffset parameter to retrieve stickers for weeks relative to the current week.
  * Weekly sticker response now includes the week offset value for improved context.

* **Bug Fixes / Validation**
  * Added validation for weekOffset with a clear error when the provided offset is out of allowed range.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->