### PR TITLE
[Feat/#60] 습관 기반 푸시 알림 스케줄러 추가

### DIFF
--- a/src/main/java/com/swyp/server/domain/habit/repository/HabitRepository.java
+++ b/src/main/java/com/swyp/server/domain/habit/repository/HabitRepository.java
@@ -5,6 +5,9 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -13,4 +16,18 @@ public interface HabitRepository extends JpaRepository<Habit, Long> {
 
     @EntityGraph(attributePaths = "user")
     List<Habit> findAllByUserIdOrderByIsCompletedAscIdDesc(Long userId);
+
+    // 미완료 습관이 있는 유저 ID 조회
+    @Query(
+            "SELECT DISTINCT h.user.id FROM Habit h WHERE h.user.id IN :userIds AND h.isCompleted = false")
+    List<Long> findUserIdsWithIncompleteHabit(@Param("userIds") List<Long> userIds);
+
+    // 습관이 하나도 없는 유저 ID 조회
+    @Query(
+            "SELECT u.id FROM User u WHERE u.id IN :userIds AND u.id NOT IN (SELECT DISTINCT h.user.id FROM Habit h WHERE h.user.id IN :userIds)")
+    List<Long> findUserIdsWithNoHabit(@Param("userIds") List<Long> userIds);
+
+    @Modifying
+    @Query(value = "DELETE FROM habits WHERE user_id = :userId", nativeQuery = true)
+    void hardDeleteAllByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/swyp/server/domain/user/service/UserWithdrawalScheduler.java
+++ b/src/main/java/com/swyp/server/domain/user/service/UserWithdrawalScheduler.java
@@ -1,5 +1,6 @@
 package com.swyp.server.domain.user.service;
 
+import com.swyp.server.domain.habit.repository.HabitRepository;
 import com.swyp.server.domain.schedule.repository.ScheduleRepository;
 import com.swyp.server.domain.sticker.repository.UserStickerRepository;
 import com.swyp.server.domain.todo.repository.TodoRepository;
@@ -25,6 +26,7 @@ public class UserWithdrawalScheduler {
     private final TodoRepository todoRepository;
     private final UserStickerRepository userStickerRepository;
     private final ScheduleRepository scheduleRepository;
+    private final HabitRepository habitRepository;
 
     @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
     @Transactional
@@ -40,6 +42,7 @@ public class UserWithdrawalScheduler {
         deletedUsers.forEach(user -> todoRepository.hardDeleteAllByUserId(user.getId()));
         deletedUsers.forEach(user -> userStickerRepository.deleteAllByUserId(user.getId()));
         deletedUsers.forEach(user -> scheduleRepository.hardDeleteAllByUserId(user.getId()));
+        deletedUsers.forEach(user -> habitRepository.hardDeleteAllByUserId(user.getId()));
 
         userRepository.deleteAll(deletedUsers);
         log.info("Hard deleted {} withdrawn users", deletedUsers.size());

--- a/src/main/java/com/swyp/server/global/notification/PushNotificationScheduler.java
+++ b/src/main/java/com/swyp/server/global/notification/PushNotificationScheduler.java
@@ -1,5 +1,6 @@
 package com.swyp.server.global.notification;
 
+import com.swyp.server.domain.habit.repository.HabitRepository;
 import com.swyp.server.domain.todo.repository.TodoRepository;
 import com.swyp.server.domain.user.entity.User;
 import com.swyp.server.domain.user.entity.UserType;
@@ -23,6 +24,7 @@ public class PushNotificationScheduler {
     private final UserRepository userRepository;
     private final TodoRepository todoRepository;
     private final NotificationService notificationService;
+    private final HabitRepository habitRepository;
 
     // 매일 09시 - 하루 시작 알림 (모든 유저)
     @Scheduled(cron = "0 0 9 * * *", zone = "Asia/Seoul")
@@ -33,7 +35,7 @@ public class PushNotificationScheduler {
         log.info("Day start notification sent to {} users", userIds.size());
     }
 
-    // 매일 17시 - 미완료 할 일 리마인드 (자녀)
+    // 매일 17시 - 미완료 할 일 리마인드 (미완료한 할일 있는 자녀한테만)
     @Scheduled(cron = "0 0 17 * * *", zone = "Asia/Seoul")
     public void sendTodoIncompleteNotification() {
         LocalDate today = LocalDate.now(SEOUL_ZONE);
@@ -48,5 +50,32 @@ public class PushNotificationScheduler {
         notificationService.sendToUsers(
                 targetIds, "해봄", "할 일을 아직 하지 않았어요. 지금 바로 완료해 보세요!", Map.of());
         log.info("Todo incomplete notification sent to {} children", targetIds.size());
+    }
+
+    // 매일 21시 - 미완료 습관 리마인드 (미완료 습관 있는 자녀한테만)
+    @Scheduled(cron = "0 0 21 * * *", zone = "Asia/Seoul")
+    public void sendHabitIncompleteNotification() {
+        List<User> children = userRepository.findAllActiveByUserType(UserType.CHILD);
+        List<Long> childIds = children.stream().map(User::getId).toList();
+        if (childIds.isEmpty()) {
+            return;
+        }
+        List<Long> targetIds = habitRepository.findUserIdsWithIncompleteHabit(childIds);
+        notificationService.sendToUsers(targetIds, "해봄", "오늘 습관, 놓치기 전에 완료해 볼까요?", Map.of());
+        log.info("Habit incomplete notification sent to {} children", targetIds.size());
+    }
+
+    // 매일 11시 - 습관 미등록 알림 (등록된 습관이 없는 공통 유저한테만)
+    @Scheduled(cron = "0 0 11 * * *", zone = "Asia/Seoul")
+    public void sendHabitNotRegisteredNotification() {
+        List<User> users = userRepository.findAllActive();
+        List<Long> userIds = users.stream().map(User::getId).toList();
+        if (userIds.isEmpty()) {
+            return;
+        }
+        List<Long> targetIds = habitRepository.findUserIdsWithNoHabit(userIds);
+        notificationService.sendToUsers(
+                targetIds, "해봄", "아직 등록된 습관이 없어요. 지금 습관을 추가해 볼까요?", Map.of());
+        log.info("Habit not registered notification sent to {} users", targetIds.size());
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #60

## ✨ 변경 사항
- 매일 21시 미완료 습관 리마인드 (미완료 습관 있는 자녀만)
- 매일 11시 습관 미등록 알림 (습관 없는 모든 유저)
- HabitRepository 조회/하드딜리트 메서드 추가
- UserWithdrawalScheduler 회원탈퇴 시 habits 하드딜리트 추가

## 📸 테스트 증명 (필수)

## 📚 리뷰어 참고 사항
- 보상 승인/새 습관 등록 이벤트 알림은 보상 API 구현 완료되면 구현 예정

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요?
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?
- [x] spotlessApply 실행했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users now receive daily reminder notifications at 21:00 (Asia/Seoul) for incomplete habits.
  * Users receive daily notifications at 11:00 (Asia/Seoul) prompting them to register a habit if none exists.

* **Chores**
  * Improved data cleanup when users withdraw accounts, ensuring all associated habit records are completely removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->