### PR TITLE
[Feat/#54] 부모용 자녀 스티커 현황 조회 API 구현

### DIFF
--- a/src/main/java/com/swyp/server/domain/sticker/controller/StickerController.java
+++ b/src/main/java/com/swyp/server/domain/sticker/controller/StickerController.java
@@ -1,5 +1,6 @@
 package com.swyp.server.domain.sticker.controller;
 
+import com.swyp.server.domain.sticker.dto.ChildrenStickerResponse;
 import com.swyp.server.domain.sticker.dto.StickerBoardResponse;
 import com.swyp.server.domain.sticker.dto.WeeklyStickerResponse;
 import com.swyp.server.domain.sticker.service.StickerQueryService;
@@ -50,5 +51,13 @@ public class StickerController {
             @AuthenticationPrincipal Long userId) {
         stickerService.confirmStickerBoard(userId);
         return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
+    @Operation(summary = "부모용 자녀 스티커 현황 조회")
+    @GetMapping("/children")
+    public ResponseEntity<ApiResponse<ChildrenStickerResponse>> getChildrenStickers(
+            @AuthenticationPrincipal Long userId) {
+        return ResponseEntity.ok(
+                ApiResponse.success(stickerQueryService.getChildrenStickers(userId)));
     }
 }

--- a/src/main/java/com/swyp/server/domain/sticker/dto/ChildStickerResponse.java
+++ b/src/main/java/com/swyp/server/domain/sticker/dto/ChildStickerResponse.java
@@ -1,0 +1,11 @@
+package com.swyp.server.domain.sticker.dto;
+
+import java.time.LocalDate;
+
+public record ChildStickerResponse(
+        Long childId,
+        String nickname,
+        int boardNumber,
+        int filledSlots,
+        int boardSize,
+        LocalDate startDate) {}

--- a/src/main/java/com/swyp/server/domain/sticker/dto/ChildStickerResponse.java
+++ b/src/main/java/com/swyp/server/domain/sticker/dto/ChildStickerResponse.java
@@ -1,6 +1,8 @@
 package com.swyp.server.domain.sticker.dto;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 
 public record ChildStickerResponse(
         Long childId,
@@ -8,4 +10,11 @@ public record ChildStickerResponse(
         int boardNumber,
         int filledSlots,
         int boardSize,
-        LocalDate startDate) {}
+        String startDate) {
+
+    public static String formatStartDate(LocalDate date) {
+        if (date == null) return null;
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd (E)", Locale.KOREAN);
+        return date.format(formatter);
+    }
+}

--- a/src/main/java/com/swyp/server/domain/sticker/dto/ChildrenStickerResponse.java
+++ b/src/main/java/com/swyp/server/domain/sticker/dto/ChildrenStickerResponse.java
@@ -1,0 +1,5 @@
+package com.swyp.server.domain.sticker.dto;
+
+import java.util.List;
+
+public record ChildrenStickerResponse(List<ChildStickerResponse> children) {}

--- a/src/main/java/com/swyp/server/domain/sticker/service/StickerQueryService.java
+++ b/src/main/java/com/swyp/server/domain/sticker/service/StickerQueryService.java
@@ -1,13 +1,15 @@
 package com.swyp.server.domain.sticker.service;
 
-import com.swyp.server.domain.sticker.dto.DateStickerResponse;
-import com.swyp.server.domain.sticker.dto.StickerBoardResponse;
-import com.swyp.server.domain.sticker.dto.WeeklyStickerResponse;
+import com.swyp.server.domain.family.entity.FamilyRelation;
+import com.swyp.server.domain.family.repository.FamilyRelationRepository;
+import com.swyp.server.domain.sticker.dto.*;
 import com.swyp.server.domain.sticker.entity.UserStickerProgress;
 import com.swyp.server.domain.sticker.repository.UserStickerProgressRepository;
 import com.swyp.server.domain.todo.service.TodoService;
+import com.swyp.server.domain.user.entity.User;
 import com.swyp.server.global.util.DateUtils;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,6 +26,7 @@ public class StickerQueryService {
 
     private final TodoService todoService;
     private final UserStickerProgressRepository progressRepository;
+    private final FamilyRelationRepository familyRelationRepository;
 
     public WeeklyStickerResponse getWeeklyStickers(Long userId, LocalDate today) {
         LocalDate startDate = DateUtils.getWeekStart(today);
@@ -83,5 +86,43 @@ public class StickerQueryService {
         int month = today.getMonthValue();
         int weekOfMonth = (today.getDayOfMonth() - 1) / 7 + 1;
         return month + "월 " + weekOfMonth + "주차";
+    }
+
+    public ChildrenStickerResponse getChildrenStickers(Long parentId) {
+        List<FamilyRelation> relations = familyRelationRepository.findAllByOwnerUserId(parentId);
+
+        List<ChildStickerResponse> children =
+                relations.stream()
+                        .map(relation -> buildChildStickerResponse(relation.getTargetUser()))
+                        .toList();
+
+        return new ChildrenStickerResponse(children);
+    }
+
+    private ChildStickerResponse buildChildStickerResponse(User child) {
+        LocalDate startDate = DateUtils.APPLICATION_LAUNCH_DATE;
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+
+        List<LocalDate> allCompletedDates =
+                todoService.getCompletedDates(child.getId(), startDate, today);
+
+        int totalCompleted = allCompletedDates.size();
+        int filledSlots = calculateFilledSlots(totalCompleted);
+        int boardNumber = (totalCompleted / BOARD_SIZE) + 1;
+
+        int boardStartIndex = (boardNumber - 1) * BOARD_SIZE;
+        LocalDate boardStartDate =
+                allCompletedDates.isEmpty()
+                        ? null
+                        : allCompletedDates.get(
+                                Math.min(boardStartIndex, allCompletedDates.size() - 1));
+
+        return new ChildStickerResponse(
+                child.getId(),
+                child.getNickname(),
+                boardNumber,
+                filledSlots,
+                BOARD_SIZE,
+                boardStartDate);
     }
 }

--- a/src/main/java/com/swyp/server/domain/sticker/service/StickerQueryService.java
+++ b/src/main/java/com/swyp/server/domain/sticker/service/StickerQueryService.java
@@ -108,14 +108,14 @@ public class StickerQueryService {
 
         int totalCompleted = allCompletedDates.size();
         int filledSlots = calculateFilledSlots(totalCompleted);
-        int boardNumber = (totalCompleted / BOARD_SIZE) + 1;
+        int currentBoard = totalCompleted / BOARD_SIZE;
+        int boardNumber = currentBoard + 1;
 
-        int boardStartIndex = (boardNumber - 1) * BOARD_SIZE;
+        int boardStartIndex = currentBoard * BOARD_SIZE;
         LocalDate boardStartDate =
-                allCompletedDates.isEmpty()
+                allCompletedDates.isEmpty() || boardStartIndex >= allCompletedDates.size()
                         ? null
-                        : allCompletedDates.get(
-                                Math.min(boardStartIndex, allCompletedDates.size() - 1));
+                        : allCompletedDates.get(boardStartIndex);
 
         return new ChildStickerResponse(
                 child.getId(),
@@ -123,6 +123,6 @@ public class StickerQueryService {
                 boardNumber,
                 filledSlots,
                 BOARD_SIZE,
-                boardStartDate);
+                ChildStickerResponse.formatStartDate(boardStartDate));
     }
 }

--- a/src/main/java/com/swyp/server/domain/sticker/service/StickerQueryService.java
+++ b/src/main/java/com/swyp/server/domain/sticker/service/StickerQueryService.java
@@ -109,9 +109,11 @@ public class StickerQueryService {
         int totalCompleted = allCompletedDates.size();
         int filledSlots = calculateFilledSlots(totalCompleted);
         int currentBoard = totalCompleted / BOARD_SIZE;
-        int boardNumber = currentBoard + 1;
 
-        int boardStartIndex = currentBoard * BOARD_SIZE;
+        // 꽉 찬 경우 현재 판 유지, 아니면 +1
+        int boardNumber = (filledSlots == BOARD_SIZE) ? currentBoard : currentBoard + 1;
+
+        int boardStartIndex = (boardNumber - 1) * BOARD_SIZE;
         LocalDate boardStartDate =
                 allCompletedDates.isEmpty() || boardStartIndex >= allCompletedDates.size()
                         ? null


### PR DESCRIPTION
## 📌 관련 이슈
- close #54

## ✨ 변경 사항
- GET /api/v1/stickers/children 구현
- 연결된 자녀별 스티커판 번호, 채워진 스티커 수, 시작 날짜(요일 포함) 반환

## 📸 테스트 증명 (필수)
로컬에서 빌드 확인

## 📚 리뷰어 참고 사항
- 부모 화면 기준으로 자녀 스티커 현황만 반환함 (showCompletePopup 없음)
- startDate는 현재 스티커판의 첫번째 스티커를 받은 날짜, 스티커가 없으면 null
- sticker 도메인에서 family 도메인 레포지토리 직접 참조함 (추후 리팩토리 가능)

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요?
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?
- [x] spotlessApply 실행했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Parents can view an overview of all their children’s sticker boards in one place: each child’s nickname, current board number, sticker progress (filled slots / total board size), and collection start date (formatted for readability).
  * The list aggregates all children for quick monitoring and shows current progress per child.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->