### PR TITLE
[Feat/#63] 연결된 사용자 할 일 및 습관 현황 조회

### DIFF
--- a/src/main/java/com/swyp/server/domain/family/controller/FamilyRelationController.java
+++ b/src/main/java/com/swyp/server/domain/family/controller/FamilyRelationController.java
@@ -2,6 +2,8 @@ package com.swyp.server.domain.family.controller;
 
 import com.swyp.server.domain.family.dto.ConnectRequest;
 import com.swyp.server.domain.family.dto.ConnectedMembersResponse;
+import com.swyp.server.domain.family.dto.FamilyDashBoardResponse;
+import com.swyp.server.domain.family.service.FamilyRelationQueryService;
 import com.swyp.server.domain.family.service.FamilyRelationService;
 import com.swyp.server.domain.user.entity.User;
 import com.swyp.server.global.response.ApiResponse;
@@ -27,6 +29,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class FamilyRelationController {
 
     private final FamilyRelationService familyRelationService;
+    private final FamilyRelationQueryService familyRelationQueryService;
 
     @Operation(summary = "초대코드로 사용자 연결")
     @PostMapping("/connect")
@@ -51,5 +54,13 @@ public class FamilyRelationController {
             @AuthenticationPrincipal Long userId, @PathVariable Long targetUserId) {
         familyRelationService.disconnect(userId, targetUserId);
         return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
+    @Operation(summary = "연결된 사용자 할 일 및 습관 현황 요약 조회")
+    @GetMapping("/dashboard")
+    public ResponseEntity<ApiResponse<FamilyDashBoardResponse>> getDashBoard(
+            @AuthenticationPrincipal Long userId) {
+        FamilyDashBoardResponse response = familyRelationQueryService.getDashBoard(userId);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/src/main/java/com/swyp/server/domain/family/dto/FamilyDashBoardResponse.java
+++ b/src/main/java/com/swyp/server/domain/family/dto/FamilyDashBoardResponse.java
@@ -1,0 +1,5 @@
+package com.swyp.server.domain.family.dto;
+
+import java.util.List;
+
+public record FamilyDashBoardResponse(List<FamilyMemberDashboardResponse> members) {}

--- a/src/main/java/com/swyp/server/domain/family/dto/FamilyMemberDashboardResponse.java
+++ b/src/main/java/com/swyp/server/domain/family/dto/FamilyMemberDashboardResponse.java
@@ -1,4 +1,4 @@
 package com.swyp.server.domain.family.dto;
 
 public record FamilyMemberDashboardResponse(
-        Long userId, String nickname, boolean todoCompleted, boolean habitCompleted) {}
+        Long userId, String nickname, TodoSummary todo, HabitSummary habit) {}

--- a/src/main/java/com/swyp/server/domain/family/dto/FamilyMemberDashboardResponse.java
+++ b/src/main/java/com/swyp/server/domain/family/dto/FamilyMemberDashboardResponse.java
@@ -1,0 +1,4 @@
+package com.swyp.server.domain.family.dto;
+
+public record FamilyMemberDashboardResponse(
+        Long userId, String nickname, boolean todoCompleted, boolean habitCompleted) {}

--- a/src/main/java/com/swyp/server/domain/family/dto/HabitSummary.java
+++ b/src/main/java/com/swyp/server/domain/family/dto/HabitSummary.java
@@ -1,0 +1,3 @@
+package com.swyp.server.domain.family.dto;
+
+public record HabitSummary(boolean completed) {}

--- a/src/main/java/com/swyp/server/domain/family/dto/TodoSummary.java
+++ b/src/main/java/com/swyp/server/domain/family/dto/TodoSummary.java
@@ -1,0 +1,3 @@
+package com.swyp.server.domain.family.dto;
+
+public record TodoSummary(int totalCount, int completedCount) {}

--- a/src/main/java/com/swyp/server/domain/family/service/FamilyRelationQueryService.java
+++ b/src/main/java/com/swyp/server/domain/family/service/FamilyRelationQueryService.java
@@ -1,0 +1,68 @@
+package com.swyp.server.domain.family.service;
+
+import com.swyp.server.domain.family.dto.FamilyDashBoardResponse;
+import com.swyp.server.domain.family.dto.FamilyMemberDashboardResponse;
+import com.swyp.server.domain.family.entity.FamilyRelation;
+import com.swyp.server.domain.family.repository.FamilyRelationRepository;
+import com.swyp.server.domain.habit.repository.HabitRepository;
+import com.swyp.server.domain.todo.repository.TodoRepository;
+import com.swyp.server.domain.user.entity.User;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FamilyRelationQueryService {
+    private final FamilyRelationRepository familyRelationRepository;
+    private final TodoRepository todoRepository;
+    private final HabitRepository habitRepository;
+
+    public FamilyDashBoardResponse getDashBoard(Long userId) {
+        List<FamilyRelation> relations = familyRelationRepository.findAllByOwnerUserId(userId);
+
+        List<User> members = relations.stream().map(FamilyRelation::getTargetUser).toList();
+
+        if (members.isEmpty()) {
+            return new FamilyDashBoardResponse(List.of());
+        }
+
+        List<Long> membersIds = members.stream().map(User::getId).toList();
+
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+
+        Set<Long> userIdsWithIncompleteTodo =
+                Set.copyOf(todoRepository.findUserIdsWithIncompleteTodo(membersIds, today));
+
+        Set<Long> userIdsWithIncompleteHabit =
+                Set.copyOf(habitRepository.findUserIdsWithIncompleteHabit(membersIds));
+
+        Set<Long> userIdsWithNoHabit =
+                Set.copyOf(habitRepository.findUserIdsWithNoHabit(membersIds));
+
+        List<FamilyMemberDashboardResponse> memberDashboardResponseList =
+                members.stream()
+                        .map(
+                                member -> {
+                                    boolean todoCompleted =
+                                            !userIdsWithIncompleteTodo.contains(member.getId());
+
+                                    boolean habitCompleted =
+                                            !userIdsWithIncompleteHabit.contains(member.getId())
+                                                    && !userIdsWithNoHabit.contains(member.getId());
+                                    return new FamilyMemberDashboardResponse(
+                                            member.getId(),
+                                            member.getNickname(),
+                                            todoCompleted,
+                                            habitCompleted);
+                                })
+                        .toList();
+
+        return new FamilyDashBoardResponse(memberDashboardResponseList);
+    }
+}

--- a/src/main/java/com/swyp/server/domain/family/service/FamilyRelationQueryService.java
+++ b/src/main/java/com/swyp/server/domain/family/service/FamilyRelationQueryService.java
@@ -2,15 +2,20 @@ package com.swyp.server.domain.family.service;
 
 import com.swyp.server.domain.family.dto.FamilyDashBoardResponse;
 import com.swyp.server.domain.family.dto.FamilyMemberDashboardResponse;
+import com.swyp.server.domain.family.dto.HabitSummary;
+import com.swyp.server.domain.family.dto.TodoSummary;
 import com.swyp.server.domain.family.entity.FamilyRelation;
 import com.swyp.server.domain.family.repository.FamilyRelationRepository;
 import com.swyp.server.domain.habit.repository.HabitRepository;
+import com.swyp.server.domain.todo.entity.Todo;
 import com.swyp.server.domain.todo.repository.TodoRepository;
 import com.swyp.server.domain.user.entity.User;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -36,8 +41,10 @@ public class FamilyRelationQueryService {
 
         LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
 
-        Set<Long> userIdsWithIncompleteTodo =
-                Set.copyOf(todoRepository.findUserIdsWithIncompleteTodo(membersIds, today));
+        List<Todo> todos = todoRepository.findAllByUserIdInAndTodoDate(membersIds, today);
+
+        Map<Long, List<Todo>> todoMap =
+                todos.stream().collect(Collectors.groupingBy(todo -> todo.getUser().getId()));
 
         Set<Long> userIdsWithIncompleteHabit =
                 Set.copyOf(habitRepository.findUserIdsWithIncompleteHabit(membersIds));
@@ -49,8 +56,15 @@ public class FamilyRelationQueryService {
                 members.stream()
                         .map(
                                 member -> {
-                                    boolean todoCompleted =
-                                            !userIdsWithIncompleteTodo.contains(member.getId());
+                                    List<Todo> memberTodos =
+                                            todoMap.getOrDefault(member.getId(), List.of());
+
+                                    int totalCount = memberTodos.size();
+                                    int completedCount =
+                                            (int)
+                                                    memberTodos.stream()
+                                                            .filter(Todo::isCompleted)
+                                                            .count();
 
                                     boolean habitCompleted =
                                             !userIdsWithIncompleteHabit.contains(member.getId())
@@ -58,8 +72,8 @@ public class FamilyRelationQueryService {
                                     return new FamilyMemberDashboardResponse(
                                             member.getId(),
                                             member.getNickname(),
-                                            todoCompleted,
-                                            habitCompleted);
+                                            new TodoSummary(totalCount, completedCount),
+                                            new HabitSummary(habitCompleted));
                                 })
                         .toList();
 

--- a/src/main/java/com/swyp/server/domain/sticker/service/StickerQueryService.java
+++ b/src/main/java/com/swyp/server/domain/sticker/service/StickerQueryService.java
@@ -134,6 +134,8 @@ public class StickerQueryService {
                 filledSlots,
                 BOARD_SIZE,
                 ChildStickerResponse.formatStartDate(boardStartDate));
+    }
+
     private void validateWeekOffset(int weekOffset) {
         if (weekOffset < MIN_WEEK_OFFSET || weekOffset > MAX_WEEK_OFFSET) {
             throw new CustomException(ErrorCode.WEEK_OFFSET_INVALID);

--- a/src/main/java/com/swyp/server/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/com/swyp/server/domain/todo/repository/TodoRepository.java
@@ -19,6 +19,8 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
     List<Todo> findAllByUserIdAndTodoDateBetween(
             Long userId, LocalDate startDate, LocalDate endDate);
 
+    List<Todo> findAllByUserIdInAndTodoDate(List<Long> userIds, LocalDate todoDate);
+
     @Modifying
     @Query(value = "DELETE FROM todos WHERE user_id = :userId", nativeQuery = true)
     void hardDeleteAllByUserId(@Param("userId") Long userId);


### PR DESCRIPTION
## 📌 관련 이슈
- close #63 

## ✨ 변경 사항
- 연결된 사용자들의 할 일 및 습관 현황 조회 API 구현
- 습관이 1개 이상 존재하고 모든 습관이 완료된 경우에만 완료 표시

## 📸 테스트 증명 (필수)
<img width="412" height="592" alt="스크린샷 2026-03-21 오전 12 16 03" src="https://github.com/user-attachments/assets/24fe8296-fc7d-42f4-9756-daa3cc098a27" />

## 📚 리뷰어 참고 사항
- 

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요?
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?
- [x] spotlessApply 실행했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a family dashboard endpoint that displays connected family members along with their todo counts and habit completion status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->