### PR TITLE
[Feat/#66] 보상 기반 이벤트 푸시 알림 구현

### DIFF
--- a/src/main/java/com/swyp/server/domain/habit/service/HabitService.java
+++ b/src/main/java/com/swyp/server/domain/habit/service/HabitService.java
@@ -202,7 +202,8 @@ public class HabitService {
             throw new CustomException(ErrorCode.FORBIDDEN);
         }
 
-        if (!habit.getReward().trim().equals(request.reward().trim())) {
+        if (habit.getReward() != null
+                && !habit.getReward().trim().equals(request.reward().trim())) {
             habit.updateReward(request.reward());
         }
 

--- a/src/main/java/com/swyp/server/domain/habit/service/HabitService.java
+++ b/src/main/java/com/swyp/server/domain/habit/service/HabitService.java
@@ -10,8 +10,10 @@ import com.swyp.server.domain.user.entity.UserType;
 import com.swyp.server.domain.user.repository.UserRepository;
 import com.swyp.server.global.exception.CustomException;
 import com.swyp.server.global.exception.ErrorCode;
+import com.swyp.server.global.notification.NotificationService;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,6 +24,7 @@ public class HabitService {
     private final FamilyRelationService familyRelationService;
     private final HabitRepository habitRepository;
     private final UserRepository userRepository;
+    private final NotificationService notificationService;
 
     @Transactional
     public Habit createHabit(Long userId, HabitCreateRequest request) {
@@ -46,7 +49,20 @@ public class HabitService {
                         .reward(reward)
                         .build();
 
-        return habitRepository.save(habit);
+        Habit savedHabit = habitRepository.save(habit);
+
+        if (user.getUserType() == UserType.CHILD) {
+            List<User> connectedMembers = familyRelationService.getConnectedMembers(userId);
+            List<Long> parentIds =
+                    connectedMembers.stream()
+                            .filter(m -> m.getUserType() == UserType.PARENT)
+                            .map(User::getId)
+                            .toList();
+            notificationService.sendToUsers(
+                    parentIds, "해봄", "새로운 보상이 추가됐어요! 지금 바로 수락해 볼까요?", Map.of());
+        }
+
+        return savedHabit;
     }
 
     @Transactional(readOnly = true)
@@ -177,10 +193,15 @@ public class HabitService {
             throw new CustomException(ErrorCode.FORBIDDEN);
         }
 
-        if(!habit.getReward().trim().equals(request.reward().trim())) {
+        if (!habit.getReward().trim().equals(request.reward().trim())) {
             habit.updateReward(request.reward());
         }
         habit.updateRewardStatus(request.rewardStatus());
+
+        if (request.rewardStatus() == RewardStatus.IN_PROGRESS) {
+            notificationService.sendToUser(
+                    habit.getUser().getId(), "해봄", "부모님이 보상을 허락해 주셨어요. 보상을 받을 때까지 파이팅!", Map.of());
+        }
     }
 
     @Transactional

--- a/src/main/java/com/swyp/server/domain/habit/service/HabitService.java
+++ b/src/main/java/com/swyp/server/domain/habit/service/HabitService.java
@@ -17,6 +17,8 @@ import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Service
 @RequiredArgsConstructor
@@ -52,14 +54,21 @@ public class HabitService {
         Habit savedHabit = habitRepository.save(habit);
 
         if (user.getUserType() == UserType.CHILD) {
-            List<User> connectedMembers = familyRelationService.getConnectedMembers(userId);
             List<Long> parentIds =
-                    connectedMembers.stream()
+                    familyRelationService.getConnectedMembers(userId).stream()
                             .filter(m -> m.getUserType() == UserType.PARENT)
                             .map(User::getId)
                             .toList();
-            notificationService.sendToUsers(
-                    parentIds, "해봄", "새로운 보상이 추가됐어요! 지금 바로 수락해 볼까요?", Map.of());
+            if (!parentIds.isEmpty()) {
+                TransactionSynchronizationManager.registerSynchronization(
+                        new TransactionSynchronization() {
+                            @Override
+                            public void afterCommit() {
+                                notificationService.sendToUsers(
+                                        parentIds, "해봄", "새로운 보상이 추가됐어요! 지금 바로 수락해 볼까요?", Map.of());
+                            }
+                        });
+            }
         }
 
         return savedHabit;
@@ -196,11 +205,21 @@ public class HabitService {
         if (!habit.getReward().trim().equals(request.reward().trim())) {
             habit.updateReward(request.reward());
         }
+
+        RewardStatus previousStatus = habit.getStatus();
         habit.updateRewardStatus(request.rewardStatus());
 
-        if (request.rewardStatus() == RewardStatus.IN_PROGRESS) {
-            notificationService.sendToUser(
-                    habit.getUser().getId(), "해봄", "부모님이 보상을 허락해 주셨어요. 보상을 받을 때까지 파이팅!", Map.of());
+        if (previousStatus != RewardStatus.IN_PROGRESS
+                && request.rewardStatus() == RewardStatus.IN_PROGRESS) {
+            Long childId = habit.getUser().getId();
+            TransactionSynchronizationManager.registerSynchronization(
+                    new TransactionSynchronization() {
+                        @Override
+                        public void afterCommit() {
+                            notificationService.sendToUser(
+                                    childId, "해봄", "부모님이 보상을 허락해 주셨어요. 보상을 받을 때까지 파이팅!", Map.of());
+                        }
+                    });
         }
     }
 


### PR DESCRIPTION
## 📌 관련 이슈
- close #66

## ✨ 변경 사항
- 자녀가 새 습관 등록 시 연결된 부모에게 즉시 푸시
- 부모가 보상 승인(진행중으로 변경) 시 해당 자녀에게 즉시 푸시

## 📸 테스트 증명 (필수)

## 📚 리뷰어 참고 사항
- 이벤트 트리거 방식입니다.

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요?
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?
- [x] spotlessApply 실행했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Parents now receive notifications when their children create a habit that includes a reward, so parents are promptly informed of new reward-based habits.
  * Habit owners receive notifications when a habit’s reward progress becomes active (moves into in-progress), keeping owners updated as reward status changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->