### PR TITLE
[Feat/#70] 사용자 초대 코드 조회 API 구현

### DIFF
--- a/src/main/java/com/swyp/server/domain/user/controller/UserController.java
+++ b/src/main/java/com/swyp/server/domain/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.swyp.server.domain.user.controller;
 
+import com.swyp.server.domain.user.dto.InviteCodeResponse;
 import com.swyp.server.domain.user.dto.ProfileRequest;
 import com.swyp.server.domain.user.dto.UserResponse;
 import com.swyp.server.domain.user.service.UserService;
@@ -46,5 +47,12 @@ public class UserController {
     public ResponseEntity<ApiResponse<Void>> agreeToTerms(@AuthenticationPrincipal Long userId) {
         userService.agreeToTerms(userId);
         return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
+    @Operation(summary = "내 초대 코드 확인")
+    @GetMapping("me/invite-code")
+    public ResponseEntity<ApiResponse<InviteCodeResponse>> getInviteCode(
+            @AuthenticationPrincipal Long userId) {
+        return ResponseEntity.ok(ApiResponse.success(userService.getInviteCode(userId)));
     }
 }

--- a/src/main/java/com/swyp/server/domain/user/dto/InviteCodeResponse.java
+++ b/src/main/java/com/swyp/server/domain/user/dto/InviteCodeResponse.java
@@ -1,0 +1,9 @@
+package com.swyp.server.domain.user.dto;
+
+import com.swyp.server.domain.user.entity.User;
+
+public record InviteCodeResponse(String inviteCode) {
+    public static InviteCodeResponse from(User user) {
+        return new InviteCodeResponse(user.getInviteCode());
+    }
+}

--- a/src/main/java/com/swyp/server/domain/user/service/UserService.java
+++ b/src/main/java/com/swyp/server/domain/user/service/UserService.java
@@ -1,6 +1,7 @@
 package com.swyp.server.domain.user.service;
 
 import com.swyp.server.domain.auth.repository.RefreshTokenRepository;
+import com.swyp.server.domain.user.dto.InviteCodeResponse;
 import com.swyp.server.domain.user.dto.UserResponse;
 import com.swyp.server.domain.user.entity.Role;
 import com.swyp.server.domain.user.entity.User;
@@ -58,6 +59,19 @@ public class UserService {
                         .findById(userId)
                         .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         return UserResponse.from(user);
+    }
+
+    @Transactional(readOnly = true)
+    public InviteCodeResponse getInviteCode(Long userId) {
+        User user =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        if (!user.isProfileCompleted()) {
+            throw new CustomException(ErrorCode.PROFILE_NOT_COMPLETED);
+        }
+        return InviteCodeResponse.from(user);
     }
 
     @Transactional

--- a/src/main/java/com/swyp/server/global/exception/ErrorCode.java
+++ b/src/main/java/com/swyp/server/global/exception/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
     // User
     USER_NOT_FOUND(40401, 404, "사용자를 찾을 수 없습니다."),
     DUPLICATE_EMAIL(40901, 409, "이미 사용 중인 이메일입니다."),
+    PROFILE_NOT_COMPLETED(40026, 400, "프로필 설정 완료 후 이용할 수 있습니다."),
 
     // Todos
     TODO_NOT_FOUND(40402, 404, "할 일을 찾을 수 없습니다."),


### PR DESCRIPTION
## 📌 관련 이슈
- close #70 

## ✨ 변경 사항
- 사용자 초대 코드 조회 API 추가

## 📸 테스트 증명 (필수)
<img width="428" height="294" alt="스크린샷 2026-03-23 오후 8 05 05" src="https://github.com/user-attachments/assets/1b76a0bb-fa43-4e2a-a756-7ec4eb8948b7" />


## 📚 리뷰어 참고 사항
- 초대 코드 구현 과정에서 프로필 온보딩이 완료되지 않았을때 에러코드를 400으로 정의하였는데,
온보딩 필요한 API 에 AOP을 적용하여 403으로 분리할지 논의해봐도 좋을것같습니다.

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요?
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?
- [x] spotlessApply 실행했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an authenticated endpoint allowing users to retrieve their personal invite code.
  * Access requires a completed profile; users with incomplete profiles receive a validation error.
  * Introduced a dedicated response payload for returning the invite code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->