### PR TITLE
[Feat/#72] 스티커 팝업 확인 시 진행도 초기화

### DIFF
--- a/src/main/java/com/swyp/server/domain/sticker/service/StickerQueryService.java
+++ b/src/main/java/com/swyp/server/domain/sticker/service/StickerQueryService.java
@@ -67,13 +67,20 @@ public class StickerQueryService {
                         .map(UserStickerProgress::getLastConfirmedCompletedDateCount)
                         .orElse(0);
 
-        int filledSlots = calculateFilledSlots(totalCompleted);
-
-        int currentBoard = totalCompleted / BOARD_SIZE;
-        int confirmedBoard = confirmedCount / BOARD_SIZE;
-        boolean showPopup = shouldShowPopup(filledSlots, currentBoard, confirmedBoard);
+        int filledSlots = calculateFilledSlots(totalCompleted, confirmedCount);
+        boolean showPopup = shouldShowPopup(totalCompleted, confirmedCount);
 
         return new StickerBoardResponse(BOARD_SIZE, filledSlots, showPopup);
+    }
+
+    private int calculateFilledSlots(int totalCompleted, int confirmedCount) {
+        int currentCompleted = totalCompleted - confirmedCount;
+        if (currentCompleted <= 0) {
+            return 0;
+        }
+
+        int remain = currentCompleted % BOARD_SIZE;
+        return remain == 0 ? BOARD_SIZE : remain;
     }
 
     private int calculateFilledSlots(int totalCompleted) {
@@ -85,9 +92,9 @@ public class StickerQueryService {
         return remain == 0 ? BOARD_SIZE : remain;
     }
 
-    private boolean shouldShowPopup(int filledSlots, int currentBoard, int confirmedBoard) {
-
-        return filledSlots == BOARD_SIZE && currentBoard > confirmedBoard;
+    private boolean shouldShowPopup(int totalCompleted, int confirmedCount) {
+        int currentCompleted = totalCompleted - confirmedCount;
+        return currentCompleted >= BOARD_SIZE;
     }
 
     private String createWeekLabel(LocalDate targetDate) {

--- a/src/main/java/com/swyp/server/domain/sticker/service/StickerQueryService.java
+++ b/src/main/java/com/swyp/server/domain/sticker/service/StickerQueryService.java
@@ -79,8 +79,10 @@ public class StickerQueryService {
             return 0;
         }
 
-        int remain = currentCompleted % BOARD_SIZE;
-        return remain == 0 ? BOARD_SIZE : remain;
+        if (currentCompleted >= BOARD_SIZE) {
+            return BOARD_SIZE;
+        }
+        return currentCompleted;
     }
 
     private int calculateFilledSlots(int totalCompleted) {

--- a/src/main/java/com/swyp/server/domain/sticker/service/StickerService.java
+++ b/src/main/java/com/swyp/server/domain/sticker/service/StickerService.java
@@ -14,6 +14,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class StickerService {
 
+    private static final int BOARD_SIZE = 30;
+
     private final TodoService todoService;
     private final UserRepository userRepository;
     private final UserStickerProgressRepository progressRepository;
@@ -24,7 +26,11 @@ public class StickerService {
         UserStickerProgress progress =
                 progressRepository.findByUserId(userId).orElseGet(() -> createProgress(userId));
 
-        progress.confirmBoard(totalCompleted);
+        int confirmedCount = progress.getLastConfirmedCompletedDateCount();
+        int currentCompleted = totalCompleted - confirmedCount;
+        int confirmTarget = confirmedCount + (currentCompleted / BOARD_SIZE) * BOARD_SIZE;
+
+        progress.confirmBoard(confirmTarget);
     }
 
     private UserStickerProgress createProgress(Long userId) {


### PR DESCRIPTION
## 📌 관련 이슈
- close #72 

## ✨ 변경 사항
- 스티커판 완료 이후 보드 진행도가 0부터 다시 시작하도록 조회 로직 수정
- 스티커판 팝업 노출 여부를 현재 보드 진행도 기준으로 계산하도록 수정

## 📸 테스트 증명 (필수)
<img width="404" height="338" alt="스크린샷 2026-03-23 오후 11 09 39" src="https://github.com/user-attachments/assets/41f8ee56-6bda-48fc-b156-47cba65bb4eb" />

<img width="289" height="196" alt="스크린샷 2026-03-23 오후 11 10 02" src="https://github.com/user-attachments/assets/3bb4042a-51d8-4e69-bf67-5d8c1fc43642" />

## 📚 리뷰어 참고 사항



## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요?
- [x]  로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?
- [x] spotlessApply 실행했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Progress display now accounts for both total and already-confirmed completions so board fill is accurate.
  * Milestone popup/notifications trigger when newly completed progress fills a board period.
  * Confirmation logic now advances confirmations in fixed 30‑day increments to align displayed milestones with actual progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->