### PR TITLE
[FIX/#69] 보상 조회 시 자녀 이름 표시 여부 수정

### DIFF
--- a/src/main/java/com/swyp/server/domain/habit/controller/HabitController.java
+++ b/src/main/java/com/swyp/server/domain/habit/controller/HabitController.java
@@ -41,7 +41,7 @@ public class HabitController {
     @Operation(summary = "보상 조회")
     @GetMapping("/rewards")
     public ResponseEntity<ApiResponse<HabitRewardListResponse>> getHabitRewards(
-            @RequestParam(required = false) RewardStatus status,
+            @RequestParam RewardStatus status,
             @AuthenticationPrincipal Long userId) {
         HabitRewardListResponse rewards = habitService.getHabitRewards(userId, status);
         return ResponseEntity.ok(ApiResponse.success(rewards));

--- a/src/main/java/com/swyp/server/domain/habit/controller/HabitController.java
+++ b/src/main/java/com/swyp/server/domain/habit/controller/HabitController.java
@@ -65,13 +65,21 @@ public class HabitController {
         return ResponseEntity.ok(ApiResponse.success(null));
     }
 
-    @Operation(summary = "보상 상태 수정")
-    @PatchMapping("/{habitId}/status")
-    public ResponseEntity<ApiResponse<Void>> updateHabitRewardStatus(
+    @Operation(summary = "보상 상태 수정(보상 확인중 -> 진행중)")
+    @PatchMapping("/{habitId}/status/in-progress")
+    public ResponseEntity<ApiResponse<Void>> updateHabitRewardStatusToInProgress(
             @AuthenticationPrincipal Long userId,
             @PathVariable Long habitId,
             @Valid @RequestBody HabitRewardUpdateRequest request) {
-        habitService.updateHabitRewardStatus(userId, habitId, request);
+        habitService.updateHabitRewardStatusToInProgress(userId, habitId, request);
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
+    @Operation(summary = "보상 상태 수정(보상 대기중 -> 완료)")
+    @PatchMapping("/{habitId}/status/complete")
+    public ResponseEntity<ApiResponse<Void>> updateHabitRewardStatusToComplete(
+            @AuthenticationPrincipal Long userId, @PathVariable Long habitId) {
+        habitService.updateHabitRewardStatusToComplete(userId, habitId);
         return ResponseEntity.ok(ApiResponse.success(null));
     }
 

--- a/src/main/java/com/swyp/server/domain/habit/controller/HabitController.java
+++ b/src/main/java/com/swyp/server/domain/habit/controller/HabitController.java
@@ -41,8 +41,7 @@ public class HabitController {
     @Operation(summary = "보상 조회")
     @GetMapping("/rewards")
     public ResponseEntity<ApiResponse<HabitRewardListResponse>> getHabitRewards(
-            @RequestParam RewardStatus status,
-            @AuthenticationPrincipal Long userId) {
+            @RequestParam RewardStatus status, @AuthenticationPrincipal Long userId) {
         HabitRewardListResponse rewards = habitService.getHabitRewards(userId, status);
         return ResponseEntity.ok(ApiResponse.success(rewards));
     }

--- a/src/main/java/com/swyp/server/domain/habit/dto/HabitResponse.java
+++ b/src/main/java/com/swyp/server/domain/habit/dto/HabitResponse.java
@@ -13,10 +13,6 @@ public record HabitResponse(
                 (habit.getUser().getUserType().equals(UserType.PARENT)) ? null : habit.getReward();
 
         return new HabitResponse(
-                habit.getId(),
-                habit.getTitle(),
-                habit.getDuration(),
-                reward,
-                habit.isCompleted());
+                habit.getId(), habit.getTitle(), habit.getDuration(), reward, habit.isCompleted());
     }
 }

--- a/src/main/java/com/swyp/server/domain/habit/dto/HabitResponse.java
+++ b/src/main/java/com/swyp/server/domain/habit/dto/HabitResponse.java
@@ -1,10 +1,11 @@
 package com.swyp.server.domain.habit.dto;
 
 import com.swyp.server.domain.habit.entity.Habit;
+import com.swyp.server.domain.habit.entity.HabitDuration;
 import com.swyp.server.domain.user.entity.UserType;
 
 public record HabitResponse(
-        Long habitId, String title, String duration, String reward, boolean isCompleted) {
+        Long habitId, String title, HabitDuration duration, String reward, boolean isCompleted) {
 
     public static HabitResponse from(Habit habit) {
 
@@ -14,7 +15,7 @@ public record HabitResponse(
         return new HabitResponse(
                 habit.getId(),
                 habit.getTitle(),
-                habit.getDuration().getLabel(),
+                habit.getDuration(),
                 reward,
                 habit.isCompleted());
     }

--- a/src/main/java/com/swyp/server/domain/habit/dto/HabitRewardDetailResponse.java
+++ b/src/main/java/com/swyp/server/domain/habit/dto/HabitRewardDetailResponse.java
@@ -1,10 +1,11 @@
 package com.swyp.server.domain.habit.dto;
 
 import com.swyp.server.domain.habit.entity.Habit;
+import com.swyp.server.domain.habit.entity.HabitDuration;
 import com.swyp.server.domain.user.entity.UserType;
 
 public record HabitRewardDetailResponse(
-        Long habitId, String title, String duration, String reward) {
+        Long habitId, String title, HabitDuration duration, String reward) {
 
     public static HabitRewardDetailResponse from(Habit habit) {
 
@@ -12,6 +13,6 @@ public record HabitRewardDetailResponse(
                 (habit.getUser().getUserType().equals(UserType.PARENT)) ? null : habit.getReward();
 
         return new HabitRewardDetailResponse(
-                habit.getId(), habit.getTitle(), habit.getDuration().getLabel(), reward);
+                habit.getId(), habit.getTitle(), habit.getDuration(), reward);
     }
 }

--- a/src/main/java/com/swyp/server/domain/habit/dto/HabitRewardDetailResponse.java
+++ b/src/main/java/com/swyp/server/domain/habit/dto/HabitRewardDetailResponse.java
@@ -2,17 +2,13 @@ package com.swyp.server.domain.habit.dto;
 
 import com.swyp.server.domain.habit.entity.Habit;
 import com.swyp.server.domain.habit.entity.HabitDuration;
-import com.swyp.server.domain.user.entity.UserType;
 
 public record HabitRewardDetailResponse(
         Long habitId, String title, HabitDuration duration, String reward) {
 
     public static HabitRewardDetailResponse from(Habit habit) {
 
-        String reward =
-                (habit.getUser().getUserType().equals(UserType.PARENT)) ? null : habit.getReward();
-
         return new HabitRewardDetailResponse(
-                habit.getId(), habit.getTitle(), habit.getDuration(), reward);
+                habit.getId(), habit.getTitle(), habit.getDuration(), habit.getReward());
     }
 }

--- a/src/main/java/com/swyp/server/domain/habit/dto/HabitRewardListResponse.java
+++ b/src/main/java/com/swyp/server/domain/habit/dto/HabitRewardListResponse.java
@@ -1,6 +1,8 @@
 package com.swyp.server.domain.habit.dto;
 
 import com.swyp.server.domain.habit.entity.Habit;
+import com.swyp.server.domain.user.entity.UserType;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -9,7 +11,7 @@ public record HabitRewardListResponse(List<HabitRewardResponse> habitRewards) {
         return new HabitRewardListResponse(new ArrayList<>());
     }
 
-    public static HabitRewardListResponse from(List<Habit> habits) {
-        return new HabitRewardListResponse(habits.stream().map(HabitRewardResponse::from).toList());
+    public static HabitRewardListResponse from(List<Habit> habits, UserType viewerType) {
+        return new HabitRewardListResponse(habits.stream().map(habit -> HabitRewardResponse.from(habit,viewerType)).toList());
     }
 }

--- a/src/main/java/com/swyp/server/domain/habit/dto/HabitRewardListResponse.java
+++ b/src/main/java/com/swyp/server/domain/habit/dto/HabitRewardListResponse.java
@@ -2,7 +2,6 @@ package com.swyp.server.domain.habit.dto;
 
 import com.swyp.server.domain.habit.entity.Habit;
 import com.swyp.server.domain.user.entity.UserType;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -12,6 +11,7 @@ public record HabitRewardListResponse(List<HabitRewardResponse> habitRewards) {
     }
 
     public static HabitRewardListResponse from(List<Habit> habits, UserType viewerType) {
-        return new HabitRewardListResponse(habits.stream().map(habit -> HabitRewardResponse.from(habit,viewerType)).toList());
+        return new HabitRewardListResponse(
+                habits.stream().map(habit -> HabitRewardResponse.from(habit, viewerType)).toList());
     }
 }

--- a/src/main/java/com/swyp/server/domain/habit/dto/HabitRewardResponse.java
+++ b/src/main/java/com/swyp/server/domain/habit/dto/HabitRewardResponse.java
@@ -14,9 +14,6 @@ public record HabitRewardResponse(
         RewardStatus status) {
     public static HabitRewardResponse from(Habit habit, UserType viewerType) {
 
-        String reward =
-                (habit.getUser().getUserType() == (UserType.PARENT)) ? null : habit.getReward();
-
         String nickname = (viewerType == (UserType.PARENT)) ? habit.getUser().getNickname() : null;
 
         return new HabitRewardResponse(
@@ -24,7 +21,7 @@ public record HabitRewardResponse(
                 habit.getTitle(),
                 nickname,
                 habit.getDuration(),
-                reward,
+                habit.getReward(),
                 habit.getStatus());
     }
 }

--- a/src/main/java/com/swyp/server/domain/habit/dto/HabitRewardResponse.java
+++ b/src/main/java/com/swyp/server/domain/habit/dto/HabitRewardResponse.java
@@ -1,6 +1,7 @@
 package com.swyp.server.domain.habit.dto;
 
 import com.swyp.server.domain.habit.entity.Habit;
+import com.swyp.server.domain.habit.entity.HabitDuration;
 import com.swyp.server.domain.habit.entity.RewardStatus;
 import com.swyp.server.domain.user.entity.UserType;
 
@@ -8,7 +9,7 @@ public record HabitRewardResponse(
         Long habitId,
         String title,
         String nickname,
-        String duration,
+        HabitDuration duration,
         String reward,
         boolean isCompleted,
         RewardStatus status) {
@@ -23,7 +24,7 @@ public record HabitRewardResponse(
                 habit.getId(),
                 habit.getTitle(),
                 nickname,
-                habit.getDuration().getLabel(),
+                habit.getDuration(),
                 reward,
                 habit.isCompleted(),
                 habit.getStatus());

--- a/src/main/java/com/swyp/server/domain/habit/dto/HabitRewardResponse.java
+++ b/src/main/java/com/swyp/server/domain/habit/dto/HabitRewardResponse.java
@@ -11,15 +11,15 @@ public record HabitRewardResponse(
         String reward,
         boolean isCompleted,
         String status) {
-    public static HabitRewardResponse from(Habit habit) {
+    public static HabitRewardResponse from(Habit habit, UserType viewerType) {
 
         String reward =
                 (habit.getUser().getUserType() == (UserType.PARENT)) ? null : habit.getReward();
 
         String nickname =
-                (habit.getUser().getUserType() == (UserType.CHILD))
-                        ? null
-                        : habit.getUser().getNickname();
+                (viewerType == (UserType.PARENT))
+                        ? habit.getUser().getNickname()
+                        : null;
 
         return new HabitRewardResponse(
                 habit.getId(),

--- a/src/main/java/com/swyp/server/domain/habit/dto/HabitRewardResponse.java
+++ b/src/main/java/com/swyp/server/domain/habit/dto/HabitRewardResponse.java
@@ -11,7 +11,6 @@ public record HabitRewardResponse(
         String nickname,
         HabitDuration duration,
         String reward,
-        boolean isCompleted,
         RewardStatus status) {
     public static HabitRewardResponse from(Habit habit, UserType viewerType) {
 
@@ -26,7 +25,6 @@ public record HabitRewardResponse(
                 nickname,
                 habit.getDuration(),
                 reward,
-                habit.isCompleted(),
                 habit.getStatus());
     }
 }

--- a/src/main/java/com/swyp/server/domain/habit/dto/HabitRewardResponse.java
+++ b/src/main/java/com/swyp/server/domain/habit/dto/HabitRewardResponse.java
@@ -1,6 +1,7 @@
 package com.swyp.server.domain.habit.dto;
 
 import com.swyp.server.domain.habit.entity.Habit;
+import com.swyp.server.domain.habit.entity.RewardStatus;
 import com.swyp.server.domain.user.entity.UserType;
 
 public record HabitRewardResponse(
@@ -10,7 +11,7 @@ public record HabitRewardResponse(
         String duration,
         String reward,
         boolean isCompleted,
-        String status) {
+        RewardStatus status) {
     public static HabitRewardResponse from(Habit habit, UserType viewerType) {
 
         String reward =
@@ -25,6 +26,6 @@ public record HabitRewardResponse(
                 habit.getDuration().getLabel(),
                 reward,
                 habit.isCompleted(),
-                habit.getStatus().getLabel());
+                habit.getStatus());
     }
 }

--- a/src/main/java/com/swyp/server/domain/habit/dto/HabitRewardResponse.java
+++ b/src/main/java/com/swyp/server/domain/habit/dto/HabitRewardResponse.java
@@ -16,10 +16,7 @@ public record HabitRewardResponse(
         String reward =
                 (habit.getUser().getUserType() == (UserType.PARENT)) ? null : habit.getReward();
 
-        String nickname =
-                (viewerType == (UserType.PARENT))
-                        ? habit.getUser().getNickname()
-                        : null;
+        String nickname = (viewerType == (UserType.PARENT)) ? habit.getUser().getNickname() : null;
 
         return new HabitRewardResponse(
                 habit.getId(),

--- a/src/main/java/com/swyp/server/domain/habit/dto/HabitRewardUpdateRequest.java
+++ b/src/main/java/com/swyp/server/domain/habit/dto/HabitRewardUpdateRequest.java
@@ -1,8 +1,5 @@
 package com.swyp.server.domain.habit.dto;
 
-import com.swyp.server.domain.habit.entity.RewardStatus;
 import jakarta.validation.constraints.NotNull;
 
-public record HabitRewardUpdateRequest(
-        @NotNull(message = "REWARD_STATUS_REQUIRED") RewardStatus rewardStatus,
-        @NotNull(message = "HABIT_REWARD_REQUIRED") String reward) {}
+public record HabitRewardUpdateRequest(@NotNull(message = "HABIT_REWARD_REQUIRED") String reward) {}

--- a/src/main/java/com/swyp/server/domain/habit/entity/Habit.java
+++ b/src/main/java/com/swyp/server/domain/habit/entity/Habit.java
@@ -3,6 +3,7 @@ package com.swyp.server.domain.habit.entity;
 import com.swyp.server.domain.user.entity.User;
 import com.swyp.server.global.SoftDeletableEntity;
 import jakarta.persistence.*;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -40,6 +41,9 @@ public class Habit extends SoftDeletableEntity {
     @Column(nullable = false)
     private RewardStatus status;
 
+    @Column(nullable = false)
+    private LocalDateTime expiredAt;
+
     @Builder
     public Habit(User user, String title, HabitDuration duration, String reward) {
         this.user = user;
@@ -48,6 +52,7 @@ public class Habit extends SoftDeletableEntity {
         this.reward = reward;
         this.isCompleted = false;
         this.status = RewardStatus.REWARD_CHECKING;
+        this.expiredAt = LocalDateTime.now().plusDays(duration.getDays());
     }
 
     public void updateTitle(String title) {
@@ -56,6 +61,7 @@ public class Habit extends SoftDeletableEntity {
 
     public void updateDuration(HabitDuration duration) {
         this.duration = duration;
+        this.expiredAt = this.getCreatedAt().plusDays(duration.getDays());
     }
 
     public void updateReward(String reward) {

--- a/src/main/java/com/swyp/server/domain/habit/repository/HabitRepository.java
+++ b/src/main/java/com/swyp/server/domain/habit/repository/HabitRepository.java
@@ -22,6 +22,7 @@ public interface HabitRepository extends JpaRepository<Habit, Long> {
     List<Habit> findAllByUserIdAndStatusOrderByIsCompletedAscIdDesc(
             Long userId, RewardStatus status);
 
+    @EntityGraph(attributePaths = "user")
     @Query(
             "SELECT h FROM Habit h "
                     + "WHERE h.user.id IN :userIds "

--- a/src/main/java/com/swyp/server/domain/habit/repository/HabitRepository.java
+++ b/src/main/java/com/swyp/server/domain/habit/repository/HabitRepository.java
@@ -2,6 +2,7 @@ package com.swyp.server.domain.habit.repository;
 
 import com.swyp.server.domain.habit.entity.Habit;
 import com.swyp.server.domain.habit.entity.RewardStatus;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
@@ -30,6 +31,13 @@ public interface HabitRepository extends JpaRepository<Habit, Long> {
                     + "ORDER BY h.isCompleted ASC, h.id DESC")
     List<Habit> findAllByUserIdsAndStatusOptional(
             @Param("userIds") List<Long> userIds, @Param("status") RewardStatus status);
+
+    @Modifying(clearAutomatically = true)
+    @Query(
+            "UPDATE Habit h SET h.status = 'REWARD_WAITING' "
+                    + "WHERE h.status = 'IN_PROGRESS' "
+                    + "AND h.expiredAt < :now")
+    void updateExpiredHabitsStatus(@Param("now") LocalDateTime now);
 
     // 미완료 습관이 있는 유저 ID 조회
     @Query(

--- a/src/main/java/com/swyp/server/domain/habit/service/HabitScheduler.java
+++ b/src/main/java/com/swyp/server/domain/habit/service/HabitScheduler.java
@@ -1,0 +1,24 @@
+package com.swyp.server.domain.habit.service;
+
+import com.swyp.server.domain.habit.repository.HabitRepository;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class HabitScheduler {
+
+    private final HabitRepository habitRepository;
+
+    @Transactional
+    @Scheduled(cron = "0 0 0 * * *")
+    public void checkExpiredHabits() {
+        log.info("만료된 습관 체크 스케줄러 시작");
+        habitRepository.updateExpiredHabitsStatus(LocalDateTime.now());
+    }
+}

--- a/src/main/java/com/swyp/server/domain/habit/service/HabitService.java
+++ b/src/main/java/com/swyp/server/domain/habit/service/HabitService.java
@@ -178,7 +178,7 @@ public class HabitService {
     }
 
     @Transactional
-    public void updateHabitRewardStatus(
+    public void updateHabitRewardStatusToInProgress(
             Long userId, Long habitId, HabitRewardUpdateRequest request) {
         User user =
                 userRepository
@@ -212,20 +212,58 @@ public class HabitService {
         }
 
         RewardStatus previousStatus = habit.getStatus();
-        habit.updateRewardStatus(request.rewardStatus());
 
-        if (previousStatus != RewardStatus.IN_PROGRESS
-                && request.rewardStatus() == RewardStatus.IN_PROGRESS) {
-            Long childId = habit.getUser().getId();
-            TransactionSynchronizationManager.registerSynchronization(
-                    new TransactionSynchronization() {
-                        @Override
-                        public void afterCommit() {
-                            notificationService.sendToUser(
-                                    childId, "해봄", "부모님이 보상을 허락해 주셨어요. 보상을 받을 때까지 파이팅!", Map.of());
-                        }
-                    });
+        if (previousStatus != RewardStatus.REWARD_CHECKING) {
+            // 이미 IN_PROGRESS거나 다른 상태라면 즉시 에러 발생!
+            throw new CustomException(ErrorCode.INVALID_HABIT_STATUS);
         }
+
+        habit.updateRewardStatus(RewardStatus.IN_PROGRESS);
+
+        Long childId = habit.getUser().getId();
+        TransactionSynchronizationManager.registerSynchronization(
+                new TransactionSynchronization() {
+                    @Override
+                    public void afterCommit() {
+                        notificationService.sendToUser(
+                                childId, "해봄", "부모님이 보상을 허락해 주셨어요. 보상을 받을 때까지 파이팅!", Map.of());
+                    }
+                });
+    }
+
+    @Transactional
+    public void updateHabitRewardStatusToComplete(Long userId, Long habitId) {
+        User user =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        if (user.getUserType() == UserType.CHILD) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
+
+        Habit habit =
+                habitRepository
+                        .findById(habitId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.HABIT_NOT_FOUND));
+
+        List<User> connectedMembers = familyRelationService.getConnectedMembers(user.getId());
+
+        boolean isYourChild =
+                connectedMembers.stream()
+                        .map(User::getId)
+                        .toList()
+                        .contains(habit.getUser().getId());
+
+        if (!isYourChild) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
+
+        if (habit.getStatus() != RewardStatus.REWARD_WAITING) {
+            throw new CustomException(ErrorCode.INVALID_HABIT_STATUS);
+        }
+
+        habit.updateRewardStatus(RewardStatus.COMPLETE);
     }
 
     @Transactional

--- a/src/main/java/com/swyp/server/domain/habit/service/HabitService.java
+++ b/src/main/java/com/swyp/server/domain/habit/service/HabitService.java
@@ -126,7 +126,8 @@ public class HabitService {
                         .findById(habitId)
                         .orElseThrow(() -> new CustomException(ErrorCode.HABIT_NOT_FOUND));
 
-        if(habit.getStatus() == RewardStatus.IN_PROGRESS || habit.getStatus() == RewardStatus.COMPLETE){
+        if (habit.getStatus() == RewardStatus.IN_PROGRESS
+                || habit.getStatus() == RewardStatus.COMPLETE) {
             throw new CustomException(ErrorCode.GET_REWARD_DETAIL_FORBIDDEN);
         }
 

--- a/src/main/java/com/swyp/server/domain/habit/service/HabitService.java
+++ b/src/main/java/com/swyp/server/domain/habit/service/HabitService.java
@@ -126,6 +126,10 @@ public class HabitService {
                         .findById(habitId)
                         .orElseThrow(() -> new CustomException(ErrorCode.HABIT_NOT_FOUND));
 
+        if(habit.getStatus() == RewardStatus.IN_PROGRESS || habit.getStatus() == RewardStatus.COMPLETE){
+            throw new CustomException(ErrorCode.GET_REWARD_DETAIL_FORBIDDEN);
+        }
+
         List<User> connectedMembers = familyRelationService.getConnectedMembers(user.getId());
 
         boolean isYourChild =

--- a/src/main/java/com/swyp/server/domain/habit/service/HabitService.java
+++ b/src/main/java/com/swyp/server/domain/habit/service/HabitService.java
@@ -107,7 +107,7 @@ public class HabitService {
         List<Habit> habits =
                 habitRepository.findAllByUserIdsAndStatusOptional(targetUserIds, status);
 
-        return HabitRewardListResponse.from(habits);
+        return HabitRewardListResponse.from(habits, user.getUserType());
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/swyp/server/domain/habit/service/HabitService.java
+++ b/src/main/java/com/swyp/server/domain/habit/service/HabitService.java
@@ -172,7 +172,6 @@ public class HabitService {
 
         if (request.isCompleted()) {
             habit.complete();
-            habit.updateRewardStatus(RewardStatus.REWARD_WAITING);
         } else {
             habit.incomplete();
         }

--- a/src/main/java/com/swyp/server/global/exception/ErrorCode.java
+++ b/src/main/java/com/swyp/server/global/exception/ErrorCode.java
@@ -62,6 +62,7 @@ public enum ErrorCode {
     SCHEDULE_DATE_REQUIRED(40017, 400, "일정 날짜는 필수입니다."),
 
     // Habit
+    GET_REWARD_DETAIL_FORBIDDEN(40301,403,"보상 상세 정보를 확인할 수 없는 상태입니다."),
     HABIT_NOT_FOUND(40406, 404, "습관을 찾을 수 없습니다."),
 
     HABIT_TITLE_REQUIRED(40020, 400, "습관 제목은 필수입니다."),

--- a/src/main/java/com/swyp/server/global/exception/ErrorCode.java
+++ b/src/main/java/com/swyp/server/global/exception/ErrorCode.java
@@ -62,7 +62,7 @@ public enum ErrorCode {
     SCHEDULE_DATE_REQUIRED(40017, 400, "일정 날짜는 필수입니다."),
 
     // Habit
-    GET_REWARD_DETAIL_FORBIDDEN(40301,403,"보상 상세 정보를 확인할 수 없는 상태입니다."),
+    GET_REWARD_DETAIL_FORBIDDEN(40301, 403, "보상 상세 정보를 확인할 수 없는 상태입니다."),
     HABIT_NOT_FOUND(40406, 404, "습관을 찾을 수 없습니다."),
 
     HABIT_TITLE_REQUIRED(40020, 400, "습관 제목은 필수입니다."),

--- a/src/main/java/com/swyp/server/global/exception/ErrorCode.java
+++ b/src/main/java/com/swyp/server/global/exception/ErrorCode.java
@@ -71,6 +71,7 @@ public enum ErrorCode {
     HABIT_REWARD_REQUIRED(40022, 400, "습관 보상 설정은 필수입니다."),
     HABIT_COMPLETED_REQUIRED(40023, 400, "습관 완료 여부는 필수입니다."),
     REWARD_STATUS_REQUIRED(40025, 400, "보상 상태는 필수입니다."),
+    INVALID_HABIT_STATUS(40026, 400, "보상 진행 상황을 변경할 수 없습니다."),
 
     INVITE_CODE_REQUIRED(40015, 400, "초대 코드는 필수입니다."),
     WEEK_OFFSET_INVALID(40024, 400, "weekOffset은 -52 이상 52 이하여야 합니다.");

--- a/src/main/java/com/swyp/server/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/swyp/server/global/exception/GlobalExceptionHandler.java
@@ -13,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -66,6 +67,17 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     public ResponseEntity<ApiResponse<Void>> handleTypeMismatchException(
             MethodArgumentTypeMismatchException e) {
+        return ResponseEntity.status(INVALID_INPUT_VALUE.getStatus())
+                .body(
+                        ApiResponse.fail(
+                                INVALID_INPUT_VALUE.getCode(), INVALID_INPUT_VALUE.getMessage()));
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMissingServletRequestParameterException(
+            MissingServletRequestParameterException e) {
+        log.warn("MissingServletRequestParameterException: {}", e.getParameterName());
+
         return ResponseEntity.status(INVALID_INPUT_VALUE.getStatus())
                 .body(
                         ApiResponse.fail(


### PR DESCRIPTION
## 📌 관련 이슈
- close #69 

## ✨ 변경 사항
- 보상 조회 시 자녀 이름 표시 여부 수정
- 보상 상태 초기화 스케줄러 기능 구현
- 습관/보상 조회 DTO HabitDuration, RewardStatus 필드 타입 String -> enum 변경 
- 보상 상태 변경 API 분리

## 📸 테스트 증명 (필수)
로컬에서 빌드 완료 

## 📚 리뷰어 참고 사항
- 배포하며 WAS가 재시작될 때와 스케줄러 동작이 시작할 때가 겹치면 만료된 습관들의 상태가 초기화되지 않을 가능성이 있습니다. 해당 부분은 배포 시간을 스케줄러 동작 시간을 피해 진행하거나 다른 방법들을 의논해보면 좋을 거 같습니다.  

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요?
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?
- [x] spotlessApply 실행했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Habits now record an expiration timestamp and a daily scheduled job moves expired habits into a reward-waiting state.
  * Responses now expose typed duration/status values for clearer client display.

* **Behavior Changes**
  * Reward displays and nickname visibility are tailored to the viewer's role (e.g., parent vs. others).
  * Access to reward details is denied while a habit is in-progress or completed.
  * Missing request parameters are handled with a specific error response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->