### PR TITLE
[Fix/#75] 다가오는 일정 날짜 유효성 검증 추가

### DIFF
--- a/src/main/java/com/swyp/server/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/com/swyp/server/domain/schedule/service/ScheduleService.java
@@ -28,6 +28,14 @@ public class ScheduleService {
 
     @Transactional
     public Schedule createSchedule(Long userId, ScheduleCreateRequest request) {
+        LocalDate today = LocalDate.now(SEOUL_ZONE);
+        if (request.scheduleDate().isBefore(today)) {
+            throw new CustomException(ErrorCode.SCHEDULE_DATE_PAST);
+        }
+        if (request.scheduleDate().isAfter(today.plusYears(5))) {
+            throw new CustomException(ErrorCode.SCHEDULE_DATE_TOO_FAR);
+        }
+
         User user =
                 userRepository
                         .findById(userId)
@@ -66,6 +74,13 @@ public class ScheduleService {
             schedule.updateCategory(request.category());
         }
         if (request.scheduleDate() != null) {
+            LocalDate today = LocalDate.now(SEOUL_ZONE);
+            if (request.scheduleDate().isBefore(today)) {
+                throw new CustomException(ErrorCode.SCHEDULE_DATE_PAST);
+            }
+            if (request.scheduleDate().isAfter(today.plusYears(5))) {
+                throw new CustomException(ErrorCode.SCHEDULE_DATE_TOO_FAR);
+            }
             schedule.updateScheduleDate(request.scheduleDate());
         }
     }

--- a/src/main/java/com/swyp/server/global/exception/ErrorCode.java
+++ b/src/main/java/com/swyp/server/global/exception/ErrorCode.java
@@ -61,6 +61,8 @@ public enum ErrorCode {
     SCHEDULE_TITLE_REQUIRED(40014, 400, "일정 제목은 필수입니다."),
     SCHEDULE_CATEGORY_REQUIRED(40016, 400, "일정 카테고리는 필수입니다."),
     SCHEDULE_DATE_REQUIRED(40017, 400, "일정 날짜는 필수입니다."),
+    SCHEDULE_DATE_PAST(40027, 400, "과거 날짜는 입력할 수 없습니다."),
+    SCHEDULE_DATE_TOO_FAR(40028, 400, "너무 먼 미래 날짜는 입력할 수 없습니다."),
 
     // Habit
     GET_REWARD_DETAIL_FORBIDDEN(40301, 403, "보상 상세 정보를 확인할 수 없는 상태입니다."),
@@ -71,7 +73,7 @@ public enum ErrorCode {
     HABIT_REWARD_REQUIRED(40022, 400, "습관 보상 설정은 필수입니다."),
     HABIT_COMPLETED_REQUIRED(40023, 400, "습관 완료 여부는 필수입니다."),
     REWARD_STATUS_REQUIRED(40025, 400, "보상 상태는 필수입니다."),
-    INVALID_HABIT_STATUS(40026, 400, "보상 진행 상황을 변경할 수 없습니다."),
+    INVALID_HABIT_STATUS(40029, 400, "보상 진행 상황을 변경할 수 없습니다."),
 
     INVITE_CODE_REQUIRED(40015, 400, "초대 코드는 필수입니다."),
     WEEK_OFFSET_INVALID(40024, 400, "weekOffset은 -52 이상 52 이하여야 합니다.");


### PR DESCRIPTION
## 📌 관련 이슈
- close #75

## ✨ 변경 사항
- 다가오는 일정 생성/수정 시 과거 날짜 입력 불가 처리
- 다가오는 일정 생성/수정 시 5년 초과 미래 날짜 입력 불가 처리
- ErrorCode SCHEDULE_DATE_PAST(40027), SCHEDULE_DATE_TOO_FAR(40028) 추가

## 📚 리뷰어 참고 사항
- 오늘 날짜는 허용
- 날짜 형식 오류는 기존과 동일하게 INVALID_INPUT_VALUE(40000) 반환

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요?
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?
- [x] spotlessApply 실행했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced schedule date validation. Schedule creation and updates now reject past dates and dates beyond the 5-year limit. Appropriate error messages inform users of validation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->