### PR TITLE
[Fix/#81] 회원탈퇴 후 동일 계정 재가입 시 충돌 수정

### DIFF
--- a/src/main/java/com/swyp/server/domain/user/entity/User.java
+++ b/src/main/java/com/swyp/server/domain/user/entity/User.java
@@ -79,4 +79,8 @@ public class User extends SoftDeletableEntity {
         this.termsAgreed = true;
         this.termsAgreedAt = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
     }
+
+    public void maskEmail() {
+        this.email = this.email + "_" + System.currentTimeMillis();
+    }
 }

--- a/src/main/java/com/swyp/server/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/swyp/server/domain/user/repository/UserRepository.java
@@ -28,4 +28,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     @Query("SELECT u FROM User u WHERE u.userType = :userType")
     List<User> findAllActiveByUserType(@Param("userType") UserType userType);
+
+    @Query(
+            value = "SELECT * FROM users WHERE email = :email AND deleted_at IS NOT NULL",
+            nativeQuery = true)
+    Optional<User> findDeletedByEmail(@Param("email") String email);
 }

--- a/src/main/java/com/swyp/server/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/swyp/server/domain/user/repository/UserRepository.java
@@ -28,9 +28,4 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     @Query("SELECT u FROM User u WHERE u.userType = :userType")
     List<User> findAllActiveByUserType(@Param("userType") UserType userType);
-
-    @Query(
-            value = "SELECT * FROM users WHERE email = :email AND deleted_at IS NOT NULL",
-            nativeQuery = true)
-    Optional<User> findDeletedByEmail(@Param("email") String email);
 }

--- a/src/main/java/com/swyp/server/domain/user/service/UserService.java
+++ b/src/main/java/com/swyp/server/domain/user/service/UserService.java
@@ -26,7 +26,6 @@ public class UserService {
 
     @Transactional
     public User findOrCreateUser(String email, String nickname, String profileImageUrl) {
-
         return userRepository
                 .findByEmail(email)
                 .orElseGet(
@@ -92,6 +91,7 @@ public class UserService {
                         .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         refreshTokenRepository.deleteByUserId(userId);
         fcmTokenRepository.deleteByUserId(userId);
+        user.maskEmail();
         user.delete();
     }
 


### PR DESCRIPTION
## 📌 관련 이슈
- close #81

## ✨ 변경 사항
- 회원탈퇴 시 email을 마스킹하여 동일 계정 재가입 가능하도록 수정
- 탈퇴 데이터는 30일간 보관 후 기존 스케줄러에 의해 hard delete

## 📚 리뷰어 참고 사항
- 탈퇴 후 재로그인 시 새 유저로 온보딩부터 시작
- 탈퇴 유저 데이터는 유저에게 노출되지 않고 운영 목적으로만 30일 보관

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요?
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?
- [x] spotlessApply 실행했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Email addresses are now anonymized when users delete their accounts, enhancing privacy protection during the account withdrawal process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->