### PR TITLE
[Feat/#85] 성장탭 API 구현

### DIFF
--- a/src/main/java/com/swyp/server/domain/growth/controller/GrowthController.java
+++ b/src/main/java/com/swyp/server/domain/growth/controller/GrowthController.java
@@ -1,0 +1,45 @@
+package com.swyp.server.domain.growth.controller;
+
+import com.swyp.server.domain.growth.dto.ChildrenGrowthResponse;
+import com.swyp.server.domain.growth.dto.GrowthHabitResponse;
+import com.swyp.server.domain.growth.dto.GrowthTodoResponse;
+import com.swyp.server.domain.growth.service.GrowthService;
+import com.swyp.server.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Growth", description = "성장탭 API")
+@RestController
+@RequestMapping("/api/v1/growth")
+@RequiredArgsConstructor
+public class GrowthController {
+
+    private final GrowthService growthService;
+
+    @Operation(summary = "자녀 - 이번 주 할 일 별 조회")
+    @GetMapping("/todo")
+    public ResponseEntity<ApiResponse<GrowthTodoResponse>> getTodoGrowth(
+            @AuthenticationPrincipal Long userId) {
+        return ResponseEntity.ok(ApiResponse.success(growthService.getTodoGrowth(userId)));
+    }
+
+    @Operation(summary = "자녀 - 이번 주 습관 별 조회")
+    @GetMapping("/habit")
+    public ResponseEntity<ApiResponse<GrowthHabitResponse>> getHabitGrowth(
+            @AuthenticationPrincipal Long userId) {
+        return ResponseEntity.ok(ApiResponse.success(growthService.getHabitGrowth(userId)));
+    }
+
+    @Operation(summary = "부모 - 연결된 자녀 성장 현황 조회")
+    @GetMapping("/children")
+    public ResponseEntity<ApiResponse<ChildrenGrowthResponse>> getChildrenGrowth(
+            @AuthenticationPrincipal Long userId) {
+        return ResponseEntity.ok(ApiResponse.success(growthService.getChildrenGrowth(userId)));
+    }
+}

--- a/src/main/java/com/swyp/server/domain/growth/dto/ChildGrowthResponse.java
+++ b/src/main/java/com/swyp/server/domain/growth/dto/ChildGrowthResponse.java
@@ -1,0 +1,4 @@
+package com.swyp.server.domain.growth.dto;
+
+public record ChildGrowthResponse(
+        Long childId, String nickname, int todoStarCount, int habitStarCount, String weekRange) {}

--- a/src/main/java/com/swyp/server/domain/growth/dto/ChildrenGrowthResponse.java
+++ b/src/main/java/com/swyp/server/domain/growth/dto/ChildrenGrowthResponse.java
@@ -1,0 +1,5 @@
+package com.swyp.server.domain.growth.dto;
+
+import java.util.List;
+
+public record ChildrenGrowthResponse(List<ChildGrowthResponse> children) {}

--- a/src/main/java/com/swyp/server/domain/growth/dto/GrowthHabitResponse.java
+++ b/src/main/java/com/swyp/server/domain/growth/dto/GrowthHabitResponse.java
@@ -1,0 +1,3 @@
+package com.swyp.server.domain.growth.dto;
+
+public record GrowthHabitResponse(int starCount, String weekRange) {}

--- a/src/main/java/com/swyp/server/domain/growth/dto/GrowthTodoResponse.java
+++ b/src/main/java/com/swyp/server/domain/growth/dto/GrowthTodoResponse.java
@@ -1,0 +1,3 @@
+package com.swyp.server.domain.growth.dto;
+
+public record GrowthTodoResponse(int starCount, String weekRange) {}

--- a/src/main/java/com/swyp/server/domain/growth/service/GrowthService.java
+++ b/src/main/java/com/swyp/server/domain/growth/service/GrowthService.java
@@ -78,7 +78,10 @@ public class GrowthService {
                 habitDailyCompletionRepository
                         .countCompletionsByUserIds(childIds, startDate, endDate)
                         .stream()
-                        .collect(Collectors.toMap(row -> (Long) row[0], row -> (Long) row[1]));
+                        .collect(
+                                Collectors.toMap(
+                                        row -> ((Number) row[0]).longValue(),
+                                        row -> ((Number) row[1]).longValue()));
 
         List<ChildGrowthResponse> children =
                 relations.stream()

--- a/src/main/java/com/swyp/server/domain/growth/service/GrowthService.java
+++ b/src/main/java/com/swyp/server/domain/growth/service/GrowthService.java
@@ -8,7 +8,6 @@ import com.swyp.server.domain.growth.dto.GrowthHabitResponse;
 import com.swyp.server.domain.growth.dto.GrowthTodoResponse;
 import com.swyp.server.domain.habit.repository.HabitDailyCompletionRepository;
 import com.swyp.server.domain.todo.repository.TodoRepository;
-import com.swyp.server.domain.todo.service.TodoService;
 import com.swyp.server.domain.user.entity.User;
 import com.swyp.server.global.util.DateUtils;
 import java.time.LocalDate;
@@ -31,7 +30,6 @@ public class GrowthService {
     private static final DateTimeFormatter WEEK_RANGE_FORMATTER =
             DateTimeFormatter.ofPattern("yyyy/MM/dd (E)", Locale.KOREAN);
 
-    private final TodoService todoService;
     private final TodoRepository todoRepository;
     private final HabitDailyCompletionRepository habitDailyCompletionRepository;
     private final FamilyRelationRepository familyRelationRepository;

--- a/src/main/java/com/swyp/server/domain/growth/service/GrowthService.java
+++ b/src/main/java/com/swyp/server/domain/growth/service/GrowthService.java
@@ -73,15 +73,16 @@ public class GrowthService {
                         .map(r -> r.getTargetUser().getId())
                         .toList();
 
-        // 습관 완료 날 수를 한 번에 조회
         Map<Long, Long> habitCompletionCountMap =
-                habitDailyCompletionRepository
-                        .countCompletionsByUserIds(childIds, startDate, endDate)
-                        .stream()
-                        .collect(
-                                Collectors.toMap(
-                                        row -> ((Number) row[0]).longValue(),
-                                        row -> ((Number) row[1]).longValue()));
+                childIds.isEmpty()
+                        ? Map.of()
+                        : habitDailyCompletionRepository
+                                .countCompletionsByUserIds(childIds, startDate, endDate)
+                                .stream()
+                                .collect(
+                                        Collectors.toMap(
+                                                row -> ((Number) row[0]).longValue(),
+                                                row -> ((Number) row[1]).longValue()));
 
         List<ChildGrowthResponse> children =
                 relations.stream()

--- a/src/main/java/com/swyp/server/domain/growth/service/GrowthService.java
+++ b/src/main/java/com/swyp/server/domain/growth/service/GrowthService.java
@@ -1,0 +1,130 @@
+package com.swyp.server.domain.growth.service;
+
+import com.swyp.server.domain.family.entity.FamilyRelation;
+import com.swyp.server.domain.family.repository.FamilyRelationRepository;
+import com.swyp.server.domain.growth.dto.ChildGrowthResponse;
+import com.swyp.server.domain.growth.dto.ChildrenGrowthResponse;
+import com.swyp.server.domain.growth.dto.GrowthHabitResponse;
+import com.swyp.server.domain.growth.dto.GrowthTodoResponse;
+import com.swyp.server.domain.habit.repository.HabitDailyCompletionRepository;
+import com.swyp.server.domain.todo.repository.TodoRepository;
+import com.swyp.server.domain.todo.service.TodoService;
+import com.swyp.server.domain.user.entity.User;
+import com.swyp.server.global.util.DateUtils;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GrowthService {
+
+    private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
+    private static final DateTimeFormatter WEEK_RANGE_FORMATTER =
+            DateTimeFormatter.ofPattern("yyyy/MM/dd (E)", Locale.KOREAN);
+
+    private final TodoService todoService;
+    private final TodoRepository todoRepository;
+    private final HabitDailyCompletionRepository habitDailyCompletionRepository;
+    private final FamilyRelationRepository familyRelationRepository;
+
+    public GrowthTodoResponse getTodoGrowth(Long userId) {
+        LocalDate today = LocalDate.now(SEOUL_ZONE);
+        LocalDate startDate = DateUtils.getWeekStart(today);
+        LocalDate endDate = DateUtils.getWeekEnd(today);
+
+        int starCount = calculateTodoStarCount(userId, startDate, endDate);
+        String weekRange = formatWeekRange(startDate, endDate);
+
+        return new GrowthTodoResponse(starCount, weekRange);
+    }
+
+    public GrowthHabitResponse getHabitGrowth(Long userId) {
+        LocalDate today = LocalDate.now(SEOUL_ZONE);
+        LocalDate startDate = DateUtils.getWeekStart(today);
+        LocalDate endDate = DateUtils.getWeekEnd(today);
+
+        int completedDays =
+                habitDailyCompletionRepository
+                        .findAllByUserIdAndCompletionDateBetween(userId, startDate, endDate)
+                        .size();
+        int starCount = calculateHabitStarCount(completedDays);
+        String weekRange = formatWeekRange(startDate, endDate);
+
+        return new GrowthHabitResponse(starCount, weekRange);
+    }
+
+    public ChildrenGrowthResponse getChildrenGrowth(Long parentId) {
+        LocalDate today = LocalDate.now(SEOUL_ZONE);
+        LocalDate startDate = DateUtils.getWeekStart(today);
+        LocalDate endDate = DateUtils.getWeekEnd(today);
+        String weekRange = formatWeekRange(startDate, endDate);
+
+        List<FamilyRelation> relations = familyRelationRepository.findAllByOwnerUserId(parentId);
+        List<Long> childIds = relations.stream().map(r -> r.getTargetUser().getId()).toList();
+
+        // 습관 완료 날 수를 한 번에 조회
+        Map<Long, Long> habitCompletionCountMap =
+                habitDailyCompletionRepository
+                        .countCompletionsByUserIds(childIds, startDate, endDate)
+                        .stream()
+                        .collect(Collectors.toMap(row -> (Long) row[0], row -> (Long) row[1]));
+
+        List<ChildGrowthResponse> children =
+                relations.stream()
+                        .map(
+                                relation -> {
+                                    User child = relation.getTargetUser();
+                                    int todoStarCount =
+                                            calculateTodoStarCount(
+                                                    child.getId(), startDate, endDate);
+                                    int habitCompletedDays =
+                                            habitCompletionCountMap
+                                                    .getOrDefault(child.getId(), 0L)
+                                                    .intValue();
+                                    int habitStarCount =
+                                            calculateHabitStarCount(habitCompletedDays);
+                                    return new ChildGrowthResponse(
+                                            child.getId(),
+                                            child.getNickname(),
+                                            todoStarCount,
+                                            habitStarCount,
+                                            weekRange);
+                                })
+                        .toList();
+
+        return new ChildrenGrowthResponse(children);
+    }
+
+    private int calculateTodoStarCount(Long userId, LocalDate startDate, LocalDate endDate) {
+        int total = todoRepository.countAllByUserIdAndDateBetween(userId, startDate, endDate);
+        if (total == 0) return 0;
+        int completed =
+                todoRepository.countCompletedByUserIdAndDateBetween(userId, startDate, endDate);
+        double rate = (double) completed / total * 100;
+        if (rate >= 80) return 3;
+        if (rate >= 50) return 2;
+        return 1;
+    }
+
+    private int calculateHabitStarCount(int completedDays) {
+        if (completedDays >= 6) return 3;
+        if (completedDays >= 3) return 2;
+        if (completedDays >= 1) return 1;
+        return 0;
+    }
+
+    private String formatWeekRange(LocalDate startDate, LocalDate endDate) {
+        return startDate.format(WEEK_RANGE_FORMATTER)
+                + " ~ "
+                + endDate.format(WEEK_RANGE_FORMATTER);
+    }
+}

--- a/src/main/java/com/swyp/server/domain/growth/service/GrowthService.java
+++ b/src/main/java/com/swyp/server/domain/growth/service/GrowthService.java
@@ -67,7 +67,11 @@ public class GrowthService {
         String weekRange = formatWeekRange(startDate, endDate);
 
         List<FamilyRelation> relations = familyRelationRepository.findAllByOwnerUserId(parentId);
-        List<Long> childIds = relations.stream().map(r -> r.getTargetUser().getId()).toList();
+        List<Long> childIds =
+                relations.stream()
+                        .filter(r -> r.getTargetUser() != null)
+                        .map(r -> r.getTargetUser().getId())
+                        .toList();
 
         // 습관 완료 날 수를 한 번에 조회
         Map<Long, Long> habitCompletionCountMap =
@@ -78,6 +82,7 @@ public class GrowthService {
 
         List<ChildGrowthResponse> children =
                 relations.stream()
+                        .filter(r -> r.getTargetUser() != null)
                         .map(
                                 relation -> {
                                     User child = relation.getTargetUser();

--- a/src/main/java/com/swyp/server/domain/habit/entity/HabitDailyCompletion.java
+++ b/src/main/java/com/swyp/server/domain/habit/entity/HabitDailyCompletion.java
@@ -1,0 +1,48 @@
+package com.swyp.server.domain.habit.entity;
+
+import com.swyp.server.domain.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+        name = "habit_daily_completions",
+        uniqueConstraints = {
+            @UniqueConstraint(
+                    name = "uk_habit_daily_completion_user_date",
+                    columnNames = {"user_id", "completion_date"})
+        })
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class HabitDailyCompletion {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "completion_date", nullable = false)
+    private LocalDate completionDate;
+
+    @Builder
+    public HabitDailyCompletion(User user, LocalDate completionDate) {
+        this.user = user;
+        this.completionDate = completionDate;
+    }
+}

--- a/src/main/java/com/swyp/server/domain/habit/repository/HabitDailyCompletionRepository.java
+++ b/src/main/java/com/swyp/server/domain/habit/repository/HabitDailyCompletionRepository.java
@@ -10,21 +10,8 @@ import org.springframework.data.repository.query.Param;
 
 public interface HabitDailyCompletionRepository extends JpaRepository<HabitDailyCompletion, Long> {
 
-    boolean existsByUserIdAndCompletionDate(Long userId, LocalDate completionDate);
-
     List<HabitDailyCompletion> findAllByUserIdAndCompletionDateBetween(
             Long userId, LocalDate startDate, LocalDate endDate);
-
-    @Query(
-            "SELECT DISTINCT h.user.id FROM HabitDailyCompletion h "
-                    + "WHERE h.user.id IN :userIds "
-                    + "AND h.completionDate BETWEEN :startDate AND :endDate "
-                    + "GROUP BY h.user.id "
-                    + "ORDER BY COUNT(h.id) DESC")
-    List<Long> findUserIdsWithCompletions(
-            @Param("userIds") List<Long> userIds,
-            @Param("startDate") LocalDate startDate,
-            @Param("endDate") LocalDate endDate);
 
     @Query(
             "SELECT h.user.id, COUNT(h.id) FROM HabitDailyCompletion h "

--- a/src/main/java/com/swyp/server/domain/habit/repository/HabitDailyCompletionRepository.java
+++ b/src/main/java/com/swyp/server/domain/habit/repository/HabitDailyCompletionRepository.java
@@ -1,0 +1,44 @@
+package com.swyp.server.domain.habit.repository;
+
+import com.swyp.server.domain.habit.entity.HabitDailyCompletion;
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface HabitDailyCompletionRepository extends JpaRepository<HabitDailyCompletion, Long> {
+
+    boolean existsByUserIdAndCompletionDate(Long userId, LocalDate completionDate);
+
+    List<HabitDailyCompletion> findAllByUserIdAndCompletionDateBetween(
+            Long userId, LocalDate startDate, LocalDate endDate);
+
+    @Query(
+            "SELECT DISTINCT h.user.id FROM HabitDailyCompletion h "
+                    + "WHERE h.user.id IN :userIds "
+                    + "AND h.completionDate BETWEEN :startDate AND :endDate "
+                    + "GROUP BY h.user.id "
+                    + "ORDER BY COUNT(h.id) DESC")
+    List<Long> findUserIdsWithCompletions(
+            @Param("userIds") List<Long> userIds,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate);
+
+    @Query(
+            "SELECT h.user.id, COUNT(h.id) FROM HabitDailyCompletion h "
+                    + "WHERE h.user.id IN :userIds "
+                    + "AND h.completionDate BETWEEN :startDate AND :endDate "
+                    + "GROUP BY h.user.id")
+    List<Object[]> countCompletionsByUserIds(
+            @Param("userIds") List<Long> userIds,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate);
+
+    @Modifying
+    @Query(
+            value = "DELETE FROM habit_daily_completions WHERE user_id = :userId",
+            nativeQuery = true)
+    void hardDeleteAllByUserId(@Param("userId") Long userId);
+}

--- a/src/main/java/com/swyp/server/domain/habit/repository/HabitDailyCompletionRepository.java
+++ b/src/main/java/com/swyp/server/domain/habit/repository/HabitDailyCompletionRepository.java
@@ -41,4 +41,6 @@ public interface HabitDailyCompletionRepository extends JpaRepository<HabitDaily
             value = "DELETE FROM habit_daily_completions WHERE user_id = :userId",
             nativeQuery = true)
     void hardDeleteAllByUserId(@Param("userId") Long userId);
+
+    void deleteByUserIdAndCompletionDate(Long userId, LocalDate completionDate);
 }

--- a/src/main/java/com/swyp/server/domain/habit/service/HabitService.java
+++ b/src/main/java/com/swyp/server/domain/habit/service/HabitService.java
@@ -3,7 +3,9 @@ package com.swyp.server.domain.habit.service;
 import com.swyp.server.domain.family.service.FamilyRelationService;
 import com.swyp.server.domain.habit.dto.*;
 import com.swyp.server.domain.habit.entity.Habit;
+import com.swyp.server.domain.habit.entity.HabitDailyCompletion;
 import com.swyp.server.domain.habit.entity.RewardStatus;
+import com.swyp.server.domain.habit.repository.HabitDailyCompletionRepository;
 import com.swyp.server.domain.habit.repository.HabitRepository;
 import com.swyp.server.domain.user.entity.User;
 import com.swyp.server.domain.user.entity.UserType;
@@ -11,6 +13,8 @@ import com.swyp.server.domain.user.repository.UserRepository;
 import com.swyp.server.global.exception.CustomException;
 import com.swyp.server.global.exception.ErrorCode;
 import com.swyp.server.global.notification.NotificationService;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -27,6 +31,7 @@ public class HabitService {
     private final HabitRepository habitRepository;
     private final UserRepository userRepository;
     private final NotificationService notificationService;
+    private final HabitDailyCompletionRepository habitDailyCompletionRepository;
 
     @Transactional
     public Habit createHabit(Long userId, HabitCreateRequest request) {
@@ -174,6 +179,15 @@ public class HabitService {
 
         if (request.isCompleted()) {
             habit.complete();
+            LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+            // 오늘 이미 기록된 경우에 중복 저장 방지
+            if (!habitDailyCompletionRepository.existsByUserIdAndCompletionDate(userId, today)) {
+                habitDailyCompletionRepository.save(
+                        HabitDailyCompletion.builder()
+                                .user(habit.getUser())
+                                .completionDate(today)
+                                .build());
+            }
         } else {
             habit.incomplete();
         }

--- a/src/main/java/com/swyp/server/domain/habit/service/HabitService.java
+++ b/src/main/java/com/swyp/server/domain/habit/service/HabitService.java
@@ -192,6 +192,9 @@ public class HabitService {
             }
         } else {
             habit.incomplete();
+            // 오늘 완료 이력 삭제
+            LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+            habitDailyCompletionRepository.deleteByUserIdAndCompletionDate(userId, today);
         }
     }
 

--- a/src/main/java/com/swyp/server/domain/habit/service/HabitService.java
+++ b/src/main/java/com/swyp/server/domain/habit/service/HabitService.java
@@ -181,12 +181,14 @@ public class HabitService {
             habit.complete();
             LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
             // 오늘 이미 기록된 경우에 중복 저장 방지
-            if (!habitDailyCompletionRepository.existsByUserIdAndCompletionDate(userId, today)) {
+            try {
                 habitDailyCompletionRepository.save(
                         HabitDailyCompletion.builder()
                                 .user(habit.getUser())
                                 .completionDate(today)
                                 .build());
+            } catch (org.springframework.dao.DataIntegrityViolationException ignored) {
+                // 동시 요청으로 이미 오늘 완료 이력이 있으면 무시
             }
         } else {
             habit.incomplete();

--- a/src/main/java/com/swyp/server/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/com/swyp/server/domain/todo/repository/TodoRepository.java
@@ -35,4 +35,23 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
             "SELECT DISTINCT t.user.id FROM Todo t WHERE t.user.id IN :userIds AND t.todoDate = :date AND t.completed = false AND t.deletedAt IS NULL")
     List<Long> findUserIdsWithIncompleteTodo(
             @Param("userIds") List<Long> userIds, @Param("date") LocalDate date);
+
+    @Query(
+            "SELECT COUNT(t) FROM Todo t WHERE t.user.id = :userId "
+                    + "AND t.todoDate BETWEEN :startDate AND :endDate "
+                    + "AND t.deletedAt IS NULL")
+    int countAllByUserIdAndDateBetween(
+            @Param("userId") Long userId,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate);
+
+    @Query(
+            "SELECT COUNT(t) FROM Todo t WHERE t.user.id = :userId "
+                    + "AND t.todoDate BETWEEN :startDate AND :endDate "
+                    + "AND t.completed = true "
+                    + "AND t.deletedAt IS NULL")
+    int countCompletedByUserIdAndDateBetween(
+            @Param("userId") Long userId,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate);
 }

--- a/src/main/java/com/swyp/server/domain/user/service/UserWithdrawalScheduler.java
+++ b/src/main/java/com/swyp/server/domain/user/service/UserWithdrawalScheduler.java
@@ -1,5 +1,6 @@
 package com.swyp.server.domain.user.service;
 
+import com.swyp.server.domain.habit.repository.HabitDailyCompletionRepository;
 import com.swyp.server.domain.habit.repository.HabitRepository;
 import com.swyp.server.domain.schedule.repository.ScheduleRepository;
 import com.swyp.server.domain.sticker.repository.UserStickerRepository;
@@ -27,6 +28,7 @@ public class UserWithdrawalScheduler {
     private final UserStickerRepository userStickerRepository;
     private final ScheduleRepository scheduleRepository;
     private final HabitRepository habitRepository;
+    private final HabitDailyCompletionRepository habitDailyCompletionRepository;
 
     @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
     @Transactional
@@ -42,6 +44,8 @@ public class UserWithdrawalScheduler {
         deletedUsers.forEach(user -> todoRepository.hardDeleteAllByUserId(user.getId()));
         deletedUsers.forEach(user -> userStickerRepository.deleteAllByUserId(user.getId()));
         deletedUsers.forEach(user -> scheduleRepository.hardDeleteAllByUserId(user.getId()));
+        deletedUsers.forEach(
+                user -> habitDailyCompletionRepository.hardDeleteAllByUserId(user.getId()));
         deletedUsers.forEach(user -> habitRepository.hardDeleteAllByUserId(user.getId()));
 
         userRepository.deleteAll(deletedUsers);


### PR DESCRIPTION
## 📌 관련 이슈
- close #85

## ✨ 변경 사항
- 자녀 - 이번 주 할 일 별 조회 API 추가 (GET /api/v1/growth/todo)
- 자녀 - 이번 주 습관 별 조회 API 추가 (GET /api/v1/growth/habit)
- 부모 - 연결된 자녀 성장 현황 조회 API 추가 (GET /api/v1/growth/children)
- 습관 완료 이력 테이블 추가 (habit_daily_completions)
- 습관 완료 시 이력 저장 로직 추가
- 회원탈퇴 시 습관 완료 이력 hard delete 추가

## 📚 리뷰어 참고 사항
- 할 일에서 별 점수 기준: 이번 주 전체 할 일 중 완료 비율 (80%↑=3개, 50~79%=2개, 50%미만=1개, 없으면 0개)
- 습관 별 점수 기준: 이번 주 습관 완료한 날 수 (6~7일=3개, 3~5일=2개, 1~2일=1개, 0일=0개)
- habit_daily_completions: user_id + completion_date unique 제약으로 중복 저장 방지

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요?
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?
- [x] spotlessApply 실행했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Weekly growth tracking APIs: view todo and habit star-rated summaries with a displayed week range.
  * Family view: parents can see each child's weekly growth metrics and summaries.

* **Bug Fixes**
  * Habit completion now records daily completions reliably (suppresses duplicate insert errors).

* **Chores**
  * Withdrawn-user cleanup now removes associated daily habit completion records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->