### PR TITLE
[Fix] 약관 HTML 페이지 인증 없이 접근 가능하도록 SecurityPath 추가

### DIFF
--- a/src/main/java/com/swyp/server/global/config/SecurityPath.java
+++ b/src/main/java/com/swyp/server/global/config/SecurityPath.java
@@ -8,5 +8,11 @@ import lombok.NoArgsConstructor;
 public final class SecurityPath {
 
     public static final List<String> PUBLIC_URLS =
-            List.of("/api/v1/auth/**", "/swagger-ui/**", "/api-docs/**", "/swagger-ui.html");
+            List.of(
+                    "/api/v1/auth/**",
+                    "/swagger-ui/**",
+                    "/api-docs/**",
+                    "/swagger-ui.html",
+                    "/privacy.html",
+                    "/terms.html");
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #87

## ✨ 변경 사항
- SecurityPath PUBLIC_URLS에 /privacy.html, /terms.html 추가

## 📚 리뷰어 참고 사항
- 약관 HTML 페이지가 인증 필터에 막혀 접근 불가한 버그 수정

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요?
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?
- [x] spotlessApply 실행했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated public access settings to include privacy and terms pages, making them accessible without authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->