### PR TITLE
[Fix/#90] 습관 완료 이력 unique key를 habit_id+날짜로 변경 - 중복 저장 오류 수정 위함

### DIFF
--- a/src/main/java/com/swyp/server/domain/growth/service/GrowthService.java
+++ b/src/main/java/com/swyp/server/domain/growth/service/GrowthService.java
@@ -50,11 +50,16 @@ public class GrowthService {
         LocalDate startDate = DateUtils.getWeekStart(today);
         LocalDate endDate = DateUtils.getWeekEnd(today);
 
-        int completedDays =
+        // habit_id별 이력이 있으므로 distinct 날짜 수로 계산
+        long completedDays =
                 habitDailyCompletionRepository
                         .findAllByUserIdAndCompletionDateBetween(userId, startDate, endDate)
-                        .size();
-        int starCount = calculateHabitStarCount(completedDays);
+                        .stream()
+                        .map(c -> c.getCompletionDate())
+                        .distinct()
+                        .count();
+
+        int starCount = calculateHabitStarCount((int) completedDays);
         String weekRange = formatWeekRange(startDate, endDate);
 
         return new GrowthHabitResponse(starCount, weekRange);

--- a/src/main/java/com/swyp/server/domain/habit/entity/HabitDailyCompletion.java
+++ b/src/main/java/com/swyp/server/domain/habit/entity/HabitDailyCompletion.java
@@ -45,8 +45,8 @@ public class HabitDailyCompletion {
     private LocalDate completionDate;
 
     @Builder
-    public HabitDailyCompletion(User user, Habit habit, LocalDate completionDate) {
-        this.user = user;
+    public HabitDailyCompletion(Habit habit, LocalDate completionDate) {
+        this.user = habit.getUser();
         this.habit = habit;
         this.completionDate = completionDate;
     }

--- a/src/main/java/com/swyp/server/domain/habit/entity/HabitDailyCompletion.java
+++ b/src/main/java/com/swyp/server/domain/habit/entity/HabitDailyCompletion.java
@@ -22,8 +22,8 @@ import lombok.NoArgsConstructor;
         name = "habit_daily_completions",
         uniqueConstraints = {
             @UniqueConstraint(
-                    name = "uk_habit_daily_completion_user_date",
-                    columnNames = {"user_id", "completion_date"})
+                    name = "uk_habit_daily_completion_habit_date",
+                    columnNames = {"habit_id", "completion_date"})
         })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -37,12 +37,17 @@ public class HabitDailyCompletion {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "habit_id", nullable = false)
+    private Habit habit;
+
     @Column(name = "completion_date", nullable = false)
     private LocalDate completionDate;
 
     @Builder
-    public HabitDailyCompletion(User user, LocalDate completionDate) {
+    public HabitDailyCompletion(User user, Habit habit, LocalDate completionDate) {
         this.user = user;
+        this.habit = habit;
         this.completionDate = completionDate;
     }
 }

--- a/src/main/java/com/swyp/server/domain/habit/repository/HabitDailyCompletionRepository.java
+++ b/src/main/java/com/swyp/server/domain/habit/repository/HabitDailyCompletionRepository.java
@@ -14,7 +14,7 @@ public interface HabitDailyCompletionRepository extends JpaRepository<HabitDaily
             Long userId, LocalDate startDate, LocalDate endDate);
 
     @Query(
-            "SELECT h.user.id, COUNT(h.id) FROM HabitDailyCompletion h "
+            "SELECT h.user.id, COUNT(DISTINCT h.completionDate) FROM HabitDailyCompletion h "
                     + "WHERE h.user.id IN :userIds "
                     + "AND h.completionDate BETWEEN :startDate AND :endDate "
                     + "GROUP BY h.user.id")
@@ -29,5 +29,5 @@ public interface HabitDailyCompletionRepository extends JpaRepository<HabitDaily
             nativeQuery = true)
     void hardDeleteAllByUserId(@Param("userId") Long userId);
 
-    void deleteByUserIdAndCompletionDate(Long userId, LocalDate completionDate);
+    void deleteByHabitIdAndCompletionDate(Long habitId, LocalDate completionDate);
 }

--- a/src/main/java/com/swyp/server/domain/habit/service/HabitService.java
+++ b/src/main/java/com/swyp/server/domain/habit/service/HabitService.java
@@ -182,11 +182,7 @@ public class HabitService {
             LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
             try {
                 habitDailyCompletionRepository.save(
-                        HabitDailyCompletion.builder()
-                                .user(habit.getUser())
-                                .habit(habit)
-                                .completionDate(today)
-                                .build());
+                        HabitDailyCompletion.builder().habit(habit).completionDate(today).build());
             } catch (org.springframework.dao.DataIntegrityViolationException ignored) {
             }
         } else {

--- a/src/main/java/com/swyp/server/domain/habit/service/HabitService.java
+++ b/src/main/java/com/swyp/server/domain/habit/service/HabitService.java
@@ -173,22 +173,24 @@ public class HabitService {
                         .findByIdAndUserId(habitId, userId)
                         .orElseThrow(() -> new CustomException(ErrorCode.HABIT_NOT_FOUND));
 
+        boolean wasCompleted = habit.isCompleted();
+        boolean nowCompleted = request.isCompleted();
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+
         habit.updateTitle(request.title());
         habit.updateDuration(request.duration());
         habit.updateReward(reward);
 
-        if (request.isCompleted()) {
-            habit.complete();
-            LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
-            try {
+        if (wasCompleted != nowCompleted) {
+            if (nowCompleted) {
+                habit.complete();
                 habitDailyCompletionRepository.save(
                         HabitDailyCompletion.builder().habit(habit).completionDate(today).build());
-            } catch (org.springframework.dao.DataIntegrityViolationException ignored) {
+            } else {
+                habit.incomplete();
+                habitDailyCompletionRepository.deleteByHabitIdAndCompletionDate(
+                        habit.getId(), today);
             }
-        } else {
-            habit.incomplete();
-            LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
-            habitDailyCompletionRepository.deleteByHabitIdAndCompletionDate(habit.getId(), today);
         }
     }
 

--- a/src/main/java/com/swyp/server/domain/habit/service/HabitService.java
+++ b/src/main/java/com/swyp/server/domain/habit/service/HabitService.java
@@ -180,21 +180,19 @@ public class HabitService {
         if (request.isCompleted()) {
             habit.complete();
             LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
-            // 오늘 이미 기록된 경우에 중복 저장 방지
             try {
                 habitDailyCompletionRepository.save(
                         HabitDailyCompletion.builder()
                                 .user(habit.getUser())
+                                .habit(habit)
                                 .completionDate(today)
                                 .build());
             } catch (org.springframework.dao.DataIntegrityViolationException ignored) {
-                // 동시 요청으로 이미 오늘 완료 이력이 있으면 무시
             }
         } else {
             habit.incomplete();
-            // 오늘 완료 이력 삭제
             LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
-            habitDailyCompletionRepository.deleteByUserIdAndCompletionDate(userId, today);
+            habitDailyCompletionRepository.deleteByHabitIdAndCompletionDate(habit.getId(), today);
         }
     }
 


### PR DESCRIPTION
## 📌 관련 이슈
- close #90

## ✨ 변경 사항
- HabitDailyCompletion unique key를 user_id+날짜 → habit_id+날짜로 변경
- HabitService.updateHabit 완료 이력 저장/삭제 시 habit_id 기준으로 변경
- HabitDailyCompletionRepository countCompletionsByUserIds를 COUNT(DISTINCT completion_date)로 수정
- GrowthService.getHabitGrowth distinct 날짜 수 기반으로 별 계산

## 📚 리뷰어 참고 사항
- 기존 habit_daily_completions 테이블 스키마 변경 필요
- 민구님 기존 습관 로직(updateHabit, resetDailyHabits) 변경 없음

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요?
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?
- [x] spotlessApply 실행했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deduplicated daily completion counts by date so progress and stars reflect distinct days.
  * Tied completion records to specific habits, ensuring correct creation and deletion of daily completions.

* **Refactor**
  * Completion updates now depend on actual state changes (completed ↔ not completed) to avoid redundant writes/deletes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->