### PR TITLE
[Feat/#93] 진행중인 습관만 조회하도록 기능 수정  + 습관 스케줄러 쿼리 수정

### DIFF
--- a/src/main/java/com/swyp/server/domain/habit/dto/HabitRewardResponse.java
+++ b/src/main/java/com/swyp/server/domain/habit/dto/HabitRewardResponse.java
@@ -11,7 +11,8 @@ public record HabitRewardResponse(
         String nickname,
         HabitDuration duration,
         String reward,
-        RewardStatus status) {
+        RewardStatus status,
+        boolean isCompleted) {
     public static HabitRewardResponse from(Habit habit, UserType viewerType) {
 
         String nickname = (viewerType == (UserType.PARENT)) ? habit.getUser().getNickname() : null;
@@ -22,6 +23,7 @@ public record HabitRewardResponse(
                 nickname,
                 habit.getDuration(),
                 habit.getReward(),
-                habit.getStatus());
+                habit.getStatus(),
+                habit.isCompleted());
     }
 }

--- a/src/main/java/com/swyp/server/domain/habit/entity/Habit.java
+++ b/src/main/java/com/swyp/server/domain/habit/entity/Habit.java
@@ -1,6 +1,7 @@
 package com.swyp.server.domain.habit.entity;
 
 import com.swyp.server.domain.user.entity.User;
+import com.swyp.server.domain.user.entity.UserType;
 import com.swyp.server.global.SoftDeletableEntity;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
@@ -52,7 +53,10 @@ public class Habit extends SoftDeletableEntity {
         this.duration = duration;
         this.reward = reward;
         this.isCompleted = false;
-        this.status = RewardStatus.REWARD_CHECKING;
+        this.status =
+                (user.getUserType() == UserType.PARENT)
+                        ? RewardStatus.IN_PROGRESS
+                        : RewardStatus.REWARD_CHECKING;
         this.expiredAt = LocalDateTime.now(ZoneId.of("Asia/Seoul")).plusDays(duration.getDays());
     }
 

--- a/src/main/java/com/swyp/server/domain/habit/repository/HabitRepository.java
+++ b/src/main/java/com/swyp/server/domain/habit/repository/HabitRepository.java
@@ -17,7 +17,12 @@ public interface HabitRepository extends JpaRepository<Habit, Long> {
     Optional<Habit> findByIdAndUserId(Long habitId, Long userId);
 
     @EntityGraph(attributePaths = "user")
-    List<Habit> findAllByUserIdOrderByIsCompletedAscIdDesc(Long userId);
+    @Query(
+            "SELECT h FROM Habit h "
+                    + "WHERE h.user.id = :userId "
+                    + "AND h.status IN ('REWARD_CHECKING', 'IN_PROGRESS') "
+                    + "ORDER BY h.isCompleted ASC, h.id DESC")
+    List<Habit> findAllActiveHabitsByUserId(@Param("userId") Long userId);
 
     @EntityGraph(attributePaths = "user")
     List<Habit> findAllByUserIdAndStatusOrderByIsCompletedAscIdDesc(
@@ -36,13 +41,22 @@ public interface HabitRepository extends JpaRepository<Habit, Long> {
 
     @Modifying(clearAutomatically = true)
     @Query(
-            "UPDATE Habit h SET h.status = 'REWARD_WAITING' "
+            "UPDATE Habit h "
+                    + "SET h.status = CASE "
+                    + "    WHEN h.user.userType = 'PARENT' THEN 'COMPLETE' "
+                    + // 부모면 바로 완료
+                    "    ELSE 'REWARD_WAITING' "
+                    + // 아니면 보상 대기
+                    "END "
                     + "WHERE h.status = 'IN_PROGRESS' "
                     + "AND h.expiredAt < :now")
     void updateExpiredHabitsStatus(@Param("now") LocalDateTime now);
 
     @Modifying(clearAutomatically = true)
-    @Query("UPDATE Habit h SET h.isCompleted = false " + "WHERE h.isCompleted = true")
+    @Query(
+            "UPDATE Habit h SET h.isCompleted = false "
+                    + " WHERE h.isCompleted = true "
+                    + " AND h.status IN ('REWARD_CHECKING', 'IN_PROGRESS')")
     void resetAllHabits();
 
     // 미완료 습관이 있는 유저 ID 조회

--- a/src/main/java/com/swyp/server/domain/habit/service/HabitService.java
+++ b/src/main/java/com/swyp/server/domain/habit/service/HabitService.java
@@ -81,7 +81,7 @@ public class HabitService {
 
     @Transactional(readOnly = true)
     public HabitListResponse getHabits(Long userId) {
-        List<Habit> habits = habitRepository.findAllByUserIdOrderByIsCompletedAscIdDesc(userId);
+        List<Habit> habits = habitRepository.findAllActiveHabitsByUserId(userId);
         return HabitListResponse.from(habits);
     }
 

--- a/src/test/java/com/swyp/server/domain/habit/HabitRepositoryTest.java
+++ b/src/test/java/com/swyp/server/domain/habit/HabitRepositoryTest.java
@@ -1,0 +1,149 @@
+package com.swyp.server.domain.habit;
+
+import com.swyp.server.domain.habit.entity.Habit;
+import com.swyp.server.domain.habit.entity.HabitDuration;
+import com.swyp.server.domain.habit.entity.RewardStatus;
+import com.swyp.server.domain.habit.repository.HabitRepository;
+import com.swyp.server.domain.user.entity.Role;
+import com.swyp.server.domain.user.entity.User;
+import com.swyp.server.domain.user.entity.UserType;
+import com.swyp.server.domain.user.repository.UserRepository;
+import com.swyp.server.global.config.JpaAuditingConfig;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@DataJpaTest
+@Import(JpaAuditingConfig.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class HabitRepositoryTest {
+
+    @Autowired private HabitRepository habitRepository;
+
+    @Autowired private UserRepository userRepository;
+
+    @PersistenceContext private EntityManager entityManager;
+
+    @Test
+    @DisplayName("매일 자정 보상 확인중, 진행중 상태의 습관들은 완료 여부가 초기화되어야 한다.")
+    void resetDailyHabits() {
+        User user =
+                User.builder()
+                        .email("testEmail")
+                        .nickname("testNickname")
+                        .profileImageUrl("testProfile")
+                        .role(Role.USER)
+                        .build();
+
+        user.completeProfile("testNickname", UserType.CHILD, "testCode");
+        user.agreeToTerms();
+
+        userRepository.save(user);
+
+        Habit habit1 =
+                Habit.builder()
+                        .user(user)
+                        .title("testTitle")
+                        .duration(HabitDuration.THREE_DAYS)
+                        .reward("testReward")
+                        .build();
+
+        Habit habit2 =
+                Habit.builder()
+                        .user(user)
+                        .title("testTitle")
+                        .duration(HabitDuration.THREE_DAYS)
+                        .reward("testReward")
+                        .build();
+
+        habit2.complete();
+        habit2.updateRewardStatus(RewardStatus.COMPLETE);
+
+        habitRepository.saveAll(List.of(habit1, habit2));
+
+        habitRepository.resetAllHabits();
+        entityManager.clear();
+
+        Habit progressedHabit = habitRepository.findById(habit1.getId()).get();
+        Habit completedHabit = habitRepository.findById(habit2.getId()).get();
+
+        Assertions.assertThat(progressedHabit.isCompleted()).isFalse();
+        Assertions.assertThat(completedHabit.isCompleted()).isTrue();
+    }
+
+    @Test
+    @DisplayName("설정기간이 만료된 자녀의 습관은 보상 대기중 상태로 부모의 습관은 완료 상태로 변경되어야 한다.")
+    void updateExpiredHabitsStatus() {
+        User child =
+                User.builder()
+                        .email("testEmail1")
+                        .nickname("testNickname1")
+                        .profileImageUrl("testProfile1")
+                        .role(Role.USER)
+                        .build();
+
+        User parent =
+                User.builder()
+                        .email("testEmail2")
+                        .nickname("testNickname2")
+                        .profileImageUrl("testProfile2")
+                        .role(Role.USER)
+                        .build();
+
+        child.completeProfile("testNickname1", UserType.CHILD, "testCo");
+        child.agreeToTerms();
+
+        parent.completeProfile("testNickname2", UserType.PARENT, "testde");
+        parent.agreeToTerms();
+
+        userRepository.saveAll(List.of(child, parent));
+
+        LocalDateTime now = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+        LocalDateTime past = now.minusDays(1); // 이미 만료된 시간
+
+        Habit childHabit =
+                Habit.builder()
+                        .user(child)
+                        .title("testTitle")
+                        .duration(HabitDuration.THREE_DAYS)
+                        .reward("testReward")
+                        .build();
+
+        Habit parentHabit =
+                Habit.builder()
+                        .user(parent)
+                        .title("testTitle")
+                        .duration(HabitDuration.THREE_DAYS)
+                        .reward(null)
+                        .build();
+
+        childHabit.complete();
+        childHabit.updateRewardStatus(RewardStatus.IN_PROGRESS);
+        ReflectionTestUtils.setField(childHabit, "expiredAt", past);
+
+        parentHabit.complete();
+        parentHabit.updateRewardStatus(RewardStatus.IN_PROGRESS);
+        ReflectionTestUtils.setField(parentHabit, "expiredAt", past);
+
+        habitRepository.saveAll(List.of(childHabit, parentHabit));
+
+        habitRepository.updateExpiredHabitsStatus(now);
+        entityManager.clear();
+
+        Habit updateChild = habitRepository.findById(childHabit.getId()).get();
+        Habit updateParent = habitRepository.findById(parentHabit.getId()).get();
+
+        Assertions.assertThat(updateChild.getStatus()).isEqualTo(RewardStatus.REWARD_WAITING);
+        Assertions.assertThat(updateParent.getStatus()).isEqualTo(RewardStatus.COMPLETE);
+    }
+}

--- a/src/test/java/com/swyp/server/domain/habit/HabitRepositoryTest.java
+++ b/src/test/java/com/swyp/server/domain/habit/HabitRepositoryTest.java
@@ -58,6 +58,9 @@ public class HabitRepositoryTest {
                         .reward("testReward")
                         .build();
 
+        habit1.complete();
+        habit1.updateRewardStatus(RewardStatus.IN_PROGRESS);
+
         Habit habit2 =
                 Habit.builder()
                         .user(user)


### PR DESCRIPTION
## 📌 관련 이슈
- close #93 

## ✨ 변경 사항
- 습관 조회 시 진행중인 습관만 조회되도록 수정
- 보상 조회 DTO에 isCompleted 필드 추가
- 습관 스케줄러 쿼리 수정 

## 📸 테스트 증명 (필수)
로컬에서 빌드 완료

## 📚 리뷰어 참고 사항
- QA 피드백 사항을 모두 반영하였습니다.
- 습관 스케줄러 검증은 서버에서 무리가 있다고 판단해 테스트 코드를 통해 진행하기로 하였습니다.

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요?
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?
- [x] spotlessApply 실행했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Habit reward responses now include completion status.

* **Improvements**
  * New habits set initial status based on user role.
  * Habit listings now return only active habits with updated ordering.
  * Expired-habit status updates respect user role when advancing status.
  * Reset operation now targets only active habits.

* **Tests**
  * Added repository tests covering reset behavior and expired-status transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->