### PR TITLE
[Fix/#95] 자녀 화면 보상 조회 시 보상 확인중 상태 보상은 진행중 상태로 표시되도록 수정

### DIFF
--- a/src/main/java/com/swyp/server/domain/habit/dto/HabitRewardResponse.java
+++ b/src/main/java/com/swyp/server/domain/habit/dto/HabitRewardResponse.java
@@ -17,7 +17,11 @@ public record HabitRewardResponse(
 
         String nickname = (viewerType == (UserType.PARENT)) ? habit.getUser().getNickname() : null;
 
-        RewardStatus status = (viewerType == (UserType.CHILD) && habit.getStatus() == RewardStatus.REWARD_CHECKING) ? RewardStatus.IN_PROGRESS : habit.getStatus();
+        RewardStatus status =
+                (viewerType == (UserType.CHILD)
+                                && habit.getStatus() == RewardStatus.REWARD_CHECKING)
+                        ? RewardStatus.IN_PROGRESS
+                        : habit.getStatus();
 
         return new HabitRewardResponse(
                 habit.getId(),

--- a/src/main/java/com/swyp/server/domain/habit/dto/HabitRewardResponse.java
+++ b/src/main/java/com/swyp/server/domain/habit/dto/HabitRewardResponse.java
@@ -17,13 +17,15 @@ public record HabitRewardResponse(
 
         String nickname = (viewerType == (UserType.PARENT)) ? habit.getUser().getNickname() : null;
 
+        RewardStatus status = (viewerType == (UserType.CHILD) && habit.getStatus() == RewardStatus.REWARD_CHECKING) ? RewardStatus.IN_PROGRESS : habit.getStatus();
+
         return new HabitRewardResponse(
                 habit.getId(),
                 habit.getTitle(),
                 nickname,
                 habit.getDuration(),
                 habit.getReward(),
-                habit.getStatus(),
+                status,
                 habit.isCompleted());
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #95 

## ✨ 변경 사항
- 자녀 화면 보상 조회 시 보상 확인중 상태 보상은 진행중 상태로 표시

## 📸 테스트 증명 (필수)
로컬에서 빌드 완료

## 📚 리뷰어 참고 사항
- 피드백 주신 보상 관련 상태 의견에 대해 반영하였습니다!

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요?
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?
- [x] spotlessApply 실행했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed habit reward status display for child users - rewards under review now correctly display as "In Progress" instead of their technical status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->