### PR TITLE
[Fix/#97] 성장탭 기준 주차를 이번 주에서 지난 주로 변경

### DIFF
--- a/src/main/java/com/swyp/server/domain/growth/service/GrowthService.java
+++ b/src/main/java/com/swyp/server/domain/growth/service/GrowthService.java
@@ -36,8 +36,9 @@ public class GrowthService {
 
     public GrowthTodoResponse getTodoGrowth(Long userId) {
         LocalDate today = LocalDate.now(SEOUL_ZONE);
-        LocalDate startDate = DateUtils.getWeekStart(today);
-        LocalDate endDate = DateUtils.getWeekEnd(today);
+        LocalDate lastWeek = today.minusWeeks(1);
+        LocalDate startDate = DateUtils.getWeekStart(lastWeek);
+        LocalDate endDate = DateUtils.getWeekEnd(lastWeek);
 
         int starCount = calculateTodoStarCount(userId, startDate, endDate);
         String weekRange = formatWeekRange(startDate, endDate);
@@ -47,8 +48,9 @@ public class GrowthService {
 
     public GrowthHabitResponse getHabitGrowth(Long userId) {
         LocalDate today = LocalDate.now(SEOUL_ZONE);
-        LocalDate startDate = DateUtils.getWeekStart(today);
-        LocalDate endDate = DateUtils.getWeekEnd(today);
+        LocalDate lastWeek = today.minusWeeks(1);
+        LocalDate startDate = DateUtils.getWeekStart(lastWeek);
+        LocalDate endDate = DateUtils.getWeekEnd(lastWeek);
 
         // habit_id별 이력이 있으므로 distinct 날짜 수로 계산
         long completedDays =
@@ -67,8 +69,9 @@ public class GrowthService {
 
     public ChildrenGrowthResponse getChildrenGrowth(Long parentId) {
         LocalDate today = LocalDate.now(SEOUL_ZONE);
-        LocalDate startDate = DateUtils.getWeekStart(today);
-        LocalDate endDate = DateUtils.getWeekEnd(today);
+        LocalDate lastWeek = today.minusWeeks(1);
+        LocalDate startDate = DateUtils.getWeekStart(lastWeek);
+        LocalDate endDate = DateUtils.getWeekEnd(lastWeek);
         String weekRange = formatWeekRange(startDate, endDate);
 
         List<FamilyRelation> relations = familyRelationRepository.findAllByOwnerUserId(parentId);


### PR DESCRIPTION
## 📌 관련 이슈
- close #97

## ✨ 변경 사항
- 성장탭 할 일/습관/자녀 성장 조회 API 기준 주차를 이번 주에서 지난 주로 변경

## 📚 리뷰어 참고 사항
- 이번 주는 데이터가 충분하지 않아 지난 주 기준으로 노출해야 해서 수정했습니다.

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요?
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?
- [x] spotlessApply 실행했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected growth metrics to report the previous week's data instead of the current week. This adjustment applies to all growth calculations including todo progress, habit completion, and activity tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->