### PR TITLE
[Fix/#99] 자녀 스티커 현황 조회 시 CHILD 유저만 반환하도록 필터링 추가

### DIFF
--- a/src/main/java/com/swyp/server/domain/sticker/service/StickerQueryService.java
+++ b/src/main/java/com/swyp/server/domain/sticker/service/StickerQueryService.java
@@ -7,6 +7,7 @@ import com.swyp.server.domain.sticker.entity.UserStickerProgress;
 import com.swyp.server.domain.sticker.repository.UserStickerProgressRepository;
 import com.swyp.server.domain.todo.service.TodoService;
 import com.swyp.server.domain.user.entity.User;
+import com.swyp.server.domain.user.entity.UserType;
 import com.swyp.server.global.exception.CustomException;
 import com.swyp.server.global.exception.ErrorCode;
 import com.swyp.server.global.util.DateUtils;
@@ -110,6 +111,11 @@ public class StickerQueryService {
 
         List<ChildStickerResponse> children =
                 relations.stream()
+                        .filter(
+                                relation ->
+                                        relation.getTargetUser() != null
+                                                && relation.getTargetUser().getUserType()
+                                                        == UserType.CHILD)
                         .map(relation -> buildChildStickerResponse(relation.getTargetUser()))
                         .toList();
 


### PR DESCRIPTION
## 📌 관련 이슈
- close #99

## ✨ 변경 사항
- getChildrenStickers에서 UserType.CHILD인 유저만 반환하도록 필터링 추가

## 📚 리뷰어 참고 사항
- 부모끼리 연결된 경우 자녀 스티커 현황에 노출되지 않아야 함

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요?
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?
- [x] spotlessApply 실행했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sticker filtering to accurately display only child user stickers, ensuring correct results are presented to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->