### PR TITLE
[fix/#102] 자녀 화면 보상 상태별 조회 필터 기능 수정

### DIFF
--- a/src/main/java/com/swyp/server/domain/habit/repository/HabitRepository.java
+++ b/src/main/java/com/swyp/server/domain/habit/repository/HabitRepository.java
@@ -32,12 +32,12 @@ public interface HabitRepository extends JpaRepository<Habit, Long> {
     @Query(
             "SELECT h FROM Habit h "
                     + "WHERE h.user.id IN :userIds "
-                    + "AND (:status IS NULL OR h.status = :status) "
+                    + "AND (:statuses IS NULL OR h.status IN :statuses) "
                     + "ORDER BY "
                     + "  CASE h.status WHEN 'COMPLETE' THEN 1 ELSE 0 END ASC, "
                     + "  h.id DESC")
     List<Habit> findAllByUserIdsAndStatusOptional(
-            @Param("userIds") List<Long> userIds, @Param("status") RewardStatus status);
+            @Param("userIds") List<Long> userIds, @Param("statuses") List<RewardStatus> statuses);
 
     @Modifying(clearAutomatically = true)
     @Query(

--- a/src/main/java/com/swyp/server/domain/habit/service/HabitService.java
+++ b/src/main/java/com/swyp/server/domain/habit/service/HabitService.java
@@ -109,10 +109,10 @@ public class HabitService {
 
         if (targetUserIds.isEmpty()) return HabitRewardListResponse.empty();
 
-        RewardStatus filteredStatus = status.isAll() ? null : status;
+        List<RewardStatus> searchStatuses = determineSearchStatuses(user.getUserType(), status);
 
         List<Habit> habits =
-                habitRepository.findAllByUserIdsAndStatusOptional(targetUserIds, filteredStatus);
+                habitRepository.findAllByUserIdsAndStatusOptional(targetUserIds, searchStatuses);
 
         return HabitRewardListResponse.from(habits, user.getUserType());
     }
@@ -290,5 +290,17 @@ public class HabitService {
                         .orElseThrow(() -> new CustomException(ErrorCode.HABIT_NOT_FOUND));
 
         habit.delete();
+    }
+
+    private List<RewardStatus> determineSearchStatuses(UserType userType, RewardStatus status) {
+        if (status == RewardStatus.ALL) {
+            return null;
+        }
+
+        if (userType == UserType.CHILD && status == RewardStatus.IN_PROGRESS) {
+            return List.of(RewardStatus.IN_PROGRESS, RewardStatus.REWARD_CHECKING);
+        }
+
+        return List.of(status);
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #102 

## ✨ 변경 사항
- 자녀 계정에서 보상 조회 필터 중 '진행중' 필터 적용 시 '보상 확인중'과 '진행중' 상태의 보상 모두 조회되도록 변경

## 📸 테스트 증명 (필수)
로컬에서 빌드 완료

## 📚 리뷰어 참고 사항
- 현재는 자녀 계정에서 보상 조회 시 '보상 확인중' 상태의 보상들을 '진행중' 상태로 보이도록 되어있는데, DB에는 원래 상태인 '보상 확인중' 상태로 그대로 있어 '진행중' 필터 적용 시 해당 보상들은 조회가 되지 않았습니다. 이러한 자녀 계정에서 '진행중' 필터 적용시  '보상 확인중'과 '진행중' 상태의 보상 모두 조회되도록 로직을 변경하였습니다.

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요?
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?
- [x] spotlessApply 실행했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced habit filtering logic to support multi-status queries and improved handling for different user account types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->