### PR TITLE
[Fix/#105, #106] 자녀 스티커 startDate null 필터링 및 성장탭 CHILD 유저 필터링 추가

### DIFF
--- a/src/main/java/com/swyp/server/domain/growth/service/GrowthService.java
+++ b/src/main/java/com/swyp/server/domain/growth/service/GrowthService.java
@@ -9,6 +9,7 @@ import com.swyp.server.domain.growth.dto.GrowthTodoResponse;
 import com.swyp.server.domain.habit.repository.HabitDailyCompletionRepository;
 import com.swyp.server.domain.todo.repository.TodoRepository;
 import com.swyp.server.domain.user.entity.User;
+import com.swyp.server.domain.user.entity.UserType;
 import com.swyp.server.global.util.DateUtils;
 import java.time.LocalDate;
 import java.time.ZoneId;
@@ -77,7 +78,11 @@ public class GrowthService {
         List<FamilyRelation> relations = familyRelationRepository.findAllByOwnerUserId(parentId);
         List<Long> childIds =
                 relations.stream()
-                        .filter(r -> r.getTargetUser() != null)
+                        .filter(
+                                r ->
+                                        r.getTargetUser() != null
+                                                && r.getTargetUser().getUserType()
+                                                        == UserType.CHILD)
                         .map(r -> r.getTargetUser().getId())
                         .toList();
 
@@ -94,7 +99,11 @@ public class GrowthService {
 
         List<ChildGrowthResponse> children =
                 relations.stream()
-                        .filter(r -> r.getTargetUser() != null)
+                        .filter(
+                                r ->
+                                        r.getTargetUser() != null
+                                                && r.getTargetUser().getUserType()
+                                                        == UserType.CHILD)
                         .map(
                                 relation -> {
                                     User child = relation.getTargetUser();

--- a/src/main/java/com/swyp/server/domain/sticker/service/StickerQueryService.java
+++ b/src/main/java/com/swyp/server/domain/sticker/service/StickerQueryService.java
@@ -117,6 +117,7 @@ public class StickerQueryService {
                                                 && relation.getTargetUser().getUserType()
                                                         == UserType.CHILD)
                         .map(relation -> buildChildStickerResponse(relation.getTargetUser()))
+                        .filter(response -> response.startDate() != null)
                         .toList();
 
         return new ChildrenStickerResponse(children);


### PR DESCRIPTION
## 📌 관련 이슈
- close #105
- close #106

## ✨ 변경 사항
- 자녀 스티커 현황 조회 시 startDate가 null인 자녀 미노출 처리
- 성장탭 부모 자녀 성장 현황 조회 시 UserType.CHILD만 반환하도록 필터링 추가

## 📚 리뷰어 참고 사항
- 부모끼리 연결된 경우 성장탭에서 상대 부모가 자녀로 노출되던 버그 수정
- 할 일을 한 번도 완료하지 않은 자녀는 스티커 현황에서 미노출

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요?
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?
- [x] spotlessApply 실행했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Growth tracking and habit completion reports now accurately filter and display data exclusively for child user accounts, ensuring improved accuracy in household progress monitoring
  * Sticker collections have been refined to properly exclude incomplete entries without valid date information, providing cleaner and more reliable visual records

<!-- end of auto-generated comment: release notes by coderabbit.ai -->