### PR TITLE
[Feat/#108] 습관 등록 알림 문구 수정 및 부모->자녀 알림 신규 추가

### DIFF
--- a/src/main/java/com/swyp/server/domain/habit/service/HabitService.java
+++ b/src/main/java/com/swyp/server/domain/habit/service/HabitService.java
@@ -65,7 +65,7 @@ public class HabitService {
                             .map(User::getId)
                             .toList();
             if (!parentIds.isEmpty()) {
-                String childNickname = user.getNickname();
+                String childNickname = user.getNickname() != null ? user.getNickname() : "자녀";
                 TransactionSynchronizationManager.registerSynchronization(
                         new TransactionSynchronization() {
                             @Override
@@ -87,7 +87,7 @@ public class HabitService {
                             .map(User::getId)
                             .toList();
             if (!childIds.isEmpty()) {
-                String parentNickname = user.getNickname();
+                String parentNickname = user.getNickname() != null ? user.getNickname() : "부모";
                 TransactionSynchronizationManager.registerSynchronization(
                         new TransactionSynchronization() {
                             @Override

--- a/src/main/java/com/swyp/server/domain/habit/service/HabitService.java
+++ b/src/main/java/com/swyp/server/domain/habit/service/HabitService.java
@@ -65,12 +65,38 @@ public class HabitService {
                             .map(User::getId)
                             .toList();
             if (!parentIds.isEmpty()) {
+                String childNickname = user.getNickname();
                 TransactionSynchronizationManager.registerSynchronization(
                         new TransactionSynchronization() {
                             @Override
                             public void afterCommit() {
                                 notificationService.sendToUsers(
-                                        parentIds, "해봄", "새로운 보상이 추가됐어요! 지금 바로 수락해 볼까요?", Map.of());
+                                        parentIds,
+                                        "해봄",
+                                        childNickname + "(이)가 새 습관을 추가했어요. 보상을 확인해 볼까요?",
+                                        Map.of());
+                            }
+                        });
+            }
+        }
+
+        if (user.getUserType() == UserType.PARENT) {
+            List<Long> childIds =
+                    familyRelationService.getConnectedMembers(userId).stream()
+                            .filter(m -> m.getUserType() == UserType.CHILD)
+                            .map(User::getId)
+                            .toList();
+            if (!childIds.isEmpty()) {
+                String parentNickname = user.getNickname();
+                TransactionSynchronizationManager.registerSynchronization(
+                        new TransactionSynchronization() {
+                            @Override
+                            public void afterCommit() {
+                                notificationService.sendToUsers(
+                                        childIds,
+                                        "해봄",
+                                        parentNickname + "님이 새 습관을 추가했어요. 함께 힘내볼까요?",
+                                        Map.of());
                             }
                         });
             }


### PR DESCRIPTION
## 📌 관련 이슈
- close #108

## ✨ 변경 사항
- 자녀 습관 등록 시 부모 알림 문구 변경
  - 기존: "새로운 보상이 추가됐어요! 지금 바로 수락해 볼까요?"
  - 변경: "{자녀닉네임}(이)가 새 습관을 추가했어요. 보상을 확인해 볼까요?"
- 부모 습관 등록 시 자녀 알림 추가
  - 추가: "{부모닉네임}님이 새 습관을 추가했어요. 함께 힘내볼까요?"

## 📚 리뷰어 참고 사항
- createHabit에서만 수정했고, 기존 로직 변경 없음
- 닉네임은 User.getNickname()에서 가져옴

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요?
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?
- [x] spotlessApply 실행했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Habit creation notifications are now personalized and role-aware: when a child adds a habit, parents receive a notification with the child's nickname; when a parent adds a habit, connected children receive a notification with the parent's nickname.
  * Notification delivery is adjusted to ensure role-dependent recipients receive the appropriate dynamic message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->