### PR TITLE
[Feat/#111] AdMob 앱 인증을 위한 app-ads.txt 추가

### DIFF
--- a/src/main/java/com/swyp/server/global/config/SecurityPath.java
+++ b/src/main/java/com/swyp/server/global/config/SecurityPath.java
@@ -14,5 +14,6 @@ public final class SecurityPath {
                     "/api-docs/**",
                     "/swagger-ui.html",
                     "/privacy.html",
-                    "/terms.html");
+                    "/terms.html",
+                    "/app-ads.txt");
 }

--- a/src/main/resources/static/app-ads.txt
+++ b/src/main/resources/static/app-ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-7290830541472397, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
## 📌 관련 이슈
- close #111

## ✨ 변경 사항
- AdMob 앱 인증을 위한 app-ads.txt 파일 추가
- SecurityPath PUBLIC_URLS에 /app-ads.txt 추가

## 📚 리뷰어 참고 사항
- 머지 후 배포하면 haebom.io.kr/app-ads.txt 접근 가능

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요?
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?
- [x] spotlessApply 실행했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Google AdSense configuration support to enable ad verification across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->