### PR TITLE
[Feat/#110] 습관 재도전 기능 구현

### DIFF
--- a/src/main/java/com/swyp/server/domain/habit/controller/HabitController.java
+++ b/src/main/java/com/swyp/server/domain/habit/controller/HabitController.java
@@ -38,6 +38,14 @@ public class HabitController {
         return ResponseEntity.ok(ApiResponse.success(habits));
     }
 
+    @Operation(summary = "재도전 습관 조회")
+    @GetMapping("/failed")
+    public ResponseEntity<ApiResponse<FailedHabitListResponse>> getFailedHabits(
+            @AuthenticationPrincipal Long userId) {
+        FailedHabitListResponse failedHabits = habitService.getFailedHabits(userId);
+        return ResponseEntity.ok(ApiResponse.success(failedHabits));
+    }
+
     @Operation(summary = "보상 조회")
     @GetMapping("/rewards")
     public ResponseEntity<ApiResponse<HabitRewardListResponse>> getHabitRewards(

--- a/src/main/java/com/swyp/server/domain/habit/controller/HabitController.java
+++ b/src/main/java/com/swyp/server/domain/habit/controller/HabitController.java
@@ -73,6 +73,14 @@ public class HabitController {
         return ResponseEntity.ok(ApiResponse.success(null));
     }
 
+    @Operation(summary = "습관 재도전")
+    @PatchMapping("/failed/{habitId}/status/in-progress")
+    public ResponseEntity<ApiResponse<Void>> retryFailedHabits(
+            @AuthenticationPrincipal Long userId, @PathVariable Long habitId) {
+        habitService.retryFailedHabit(userId, habitId);
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
     @Operation(summary = "보상 상태 수정(보상 확인중 -> 진행중)")
     @PatchMapping("/{habitId}/status/in-progress")
     public ResponseEntity<ApiResponse<Void>> updateHabitRewardStatusToInProgress(

--- a/src/main/java/com/swyp/server/domain/habit/dto/FailedHabitListResponse.java
+++ b/src/main/java/com/swyp/server/domain/habit/dto/FailedHabitListResponse.java
@@ -1,0 +1,10 @@
+package com.swyp.server.domain.habit.dto;
+
+import com.swyp.server.domain.habit.entity.Habit;
+import java.util.List;
+
+public record FailedHabitListResponse(List<FailedHabitResponse> failedHabits) {
+    public static FailedHabitListResponse from(List<Habit> habits) {
+        return new FailedHabitListResponse(habits.stream().map(FailedHabitResponse::from).toList());
+    }
+}

--- a/src/main/java/com/swyp/server/domain/habit/dto/FailedHabitResponse.java
+++ b/src/main/java/com/swyp/server/domain/habit/dto/FailedHabitResponse.java
@@ -1,0 +1,18 @@
+package com.swyp.server.domain.habit.dto;
+
+import com.swyp.server.domain.habit.entity.Habit;
+import com.swyp.server.domain.habit.entity.HabitDuration;
+import com.swyp.server.domain.user.entity.UserType;
+
+public record FailedHabitResponse(
+        Long habitId, String title, HabitDuration duration, String reward) {
+
+    public static FailedHabitResponse from(Habit habit) {
+
+        String reward =
+                (habit.getUser().getUserType() == (UserType.PARENT)) ? null : habit.getReward();
+
+        return new FailedHabitResponse(
+                habit.getId(), habit.getTitle(), habit.getDuration(), reward);
+    }
+}

--- a/src/main/java/com/swyp/server/domain/habit/entity/Habit.java
+++ b/src/main/java/com/swyp/server/domain/habit/entity/Habit.java
@@ -88,4 +88,13 @@ public class Habit extends SoftDeletableEntity {
     public void updateRewardStatus(RewardStatus rewardStatus) {
         this.status = rewardStatus;
     }
+
+    public void retry(User user) {
+        this.status =
+                user.getUserType() == UserType.CHILD
+                        ? RewardStatus.REWARD_CHECKING
+                        : RewardStatus.IN_PROGRESS;
+
+        this.failCount = 0;
+    }
 }

--- a/src/main/java/com/swyp/server/domain/habit/entity/Habit.java
+++ b/src/main/java/com/swyp/server/domain/habit/entity/Habit.java
@@ -46,6 +46,9 @@ public class Habit extends SoftDeletableEntity {
     @Column(nullable = false)
     private LocalDateTime expiredAt;
 
+    @Column(nullable = false)
+    private int failCount;
+
     @Builder
     public Habit(User user, String title, HabitDuration duration, String reward) {
         this.user = user;
@@ -58,6 +61,7 @@ public class Habit extends SoftDeletableEntity {
                         ? RewardStatus.IN_PROGRESS
                         : RewardStatus.REWARD_CHECKING;
         this.expiredAt = LocalDateTime.now(ZoneId.of("Asia/Seoul")).plusDays(duration.getDays());
+        this.failCount = 0;
     }
 
     public void updateTitle(String title) {

--- a/src/main/java/com/swyp/server/domain/habit/entity/RewardStatus.java
+++ b/src/main/java/com/swyp/server/domain/habit/entity/RewardStatus.java
@@ -10,7 +10,8 @@ public enum RewardStatus {
     REWARD_WAITING("보상 대기중"),
     IN_PROGRESS("진행중"),
     COMPLETE("완료"),
-    ALL("전체");
+    ALL("전체"),
+    FAIL("실패");
 
     private final String label;
 

--- a/src/main/java/com/swyp/server/domain/habit/repository/HabitRepository.java
+++ b/src/main/java/com/swyp/server/domain/habit/repository/HabitRepository.java
@@ -62,17 +62,54 @@ public interface HabitRepository extends JpaRepository<Habit, Long> {
 
     @Modifying(clearAutomatically = true)
     @Query(
+            "UPDATE Habit h SET h.status = 'FAIL' "
+                    + " WHERE h.isCompleted = false "
+                    + " AND h.status IN ('REWARD_CHECKING', 'IN_PROGRESS')"
+                    + " AND h.duration IN ('THREE_DAYS', 'SEVEN_DAYS')")
+    void updateImmediateFailureHabits();
+
+    @Modifying(clearAutomatically = true)
+    @Query(
+            "UPDATE Habit h SET h.status = 'FAIL' "
+                    + " WHERE h.failCount > 1 "
+                    + " AND h.status IN ('REWARD_CHECKING', 'IN_PROGRESS')"
+                    + " AND h.duration NOT IN ('THREE_DAYS', 'SEVEN_DAYS')")
+    void updateCumulativeFailureHabits();
+
+    @Modifying(clearAutomatically = true)
+    @Query(
+            "UPDATE Habit h SET h.failCount = h.failCount + 1 "
+                    + " WHERE h.isCompleted = false "
+                    + " AND h.status IN ('REWARD_CHECKING', 'IN_PROGRESS') "
+                    + " AND h.duration NOT IN ('THREE_DAYS', 'SEVEN_DAYS')")
+    void updateHabitFailCount();
+
+    @Modifying(clearAutomatically = true)
+    @Query(
+            value =
+                    "UPDATE habits h SET h.fail_count = 0 "
+                            + "WHERE DATEDIFF(:today, h.created_at) > 0 "
+                            + "AND DATEDIFF(:today, h.created_at) % 10 = 0 "
+                            + "AND h.status IN ('REWARD_CHECKING', 'IN_PROGRESS') "
+                            + "AND h.duration NOT IN ('THREE_DAYS', 'SEVEN_DAYS')",
+            nativeQuery = true)
+    void resetFailCount(@Param("today") LocalDateTime today);
+
+    @Modifying(clearAutomatically = true)
+    @Query(
             "UPDATE Habit h SET h.isCompleted = false "
                     + " WHERE h.isCompleted = true "
                     + " AND h.status IN ('REWARD_CHECKING', 'IN_PROGRESS')")
     void resetAllHabits();
 
     // 미완료 습관이 있는 유저 ID 조회
+
     @Query(
             "SELECT DISTINCT h.user.id FROM Habit h WHERE h.user.id IN :userIds AND h.isCompleted = false")
     List<Long> findUserIdsWithIncompleteHabit(@Param("userIds") List<Long> userIds);
 
     // 습관이 하나도 없는 유저 ID 조회
+
     @Query(
             "SELECT u.id FROM User u WHERE u.id IN :userIds AND u.id NOT IN (SELECT DISTINCT h.user.id FROM Habit h WHERE h.user.id IN :userIds)")
     List<Long> findUserIdsWithNoHabit(@Param("userIds") List<Long> userIds);

--- a/src/main/java/com/swyp/server/domain/habit/repository/HabitRepository.java
+++ b/src/main/java/com/swyp/server/domain/habit/repository/HabitRepository.java
@@ -25,6 +25,10 @@ public interface HabitRepository extends JpaRepository<Habit, Long> {
     List<Habit> findAllActiveHabitsByUserId(@Param("userId") Long userId);
 
     @EntityGraph(attributePaths = "user")
+    @Query("SELECT h FROM Habit h " + "WHERE h.user.id = :userId " + "AND h.status = 'FAIL'")
+    List<Habit> findAllFailedHabitsByUserId(@Param("userId") Long userId);
+
+    @EntityGraph(attributePaths = "user")
     List<Habit> findAllByUserIdAndStatusOrderByIsCompletedAscIdDesc(
             Long userId, RewardStatus status);
 

--- a/src/main/java/com/swyp/server/domain/habit/repository/HabitRepository.java
+++ b/src/main/java/com/swyp/server/domain/habit/repository/HabitRepository.java
@@ -38,7 +38,7 @@ public interface HabitRepository extends JpaRepository<Habit, Long> {
     @Query(
             "SELECT h FROM Habit h "
                     + "WHERE h.user.id IN :userIds "
-                    + "AND (:statuses IS NULL OR h.status IN :statuses) "
+                    + "AND h.status IN :statuses "
                     + "ORDER BY "
                     + "  CASE h.status WHEN 'COMPLETE' THEN 1 ELSE 0 END ASC, "
                     + "  h.id DESC")

--- a/src/main/java/com/swyp/server/domain/habit/repository/HabitRepository.java
+++ b/src/main/java/com/swyp/server/domain/habit/repository/HabitRepository.java
@@ -92,6 +92,7 @@ public interface HabitRepository extends JpaRepository<Habit, Long> {
                     "UPDATE habits h SET h.fail_count = 0 "
                             + "WHERE DATEDIFF(:today, h.created_at) > 0 "
                             + "AND DATEDIFF(:today, h.created_at) % 10 = 0 "
+                            + "AND h.fail_count < 2 "
                             + "AND h.status IN ('REWARD_CHECKING', 'IN_PROGRESS') "
                             + "AND h.duration NOT IN ('THREE_DAYS', 'SEVEN_DAYS')",
             nativeQuery = true)

--- a/src/main/java/com/swyp/server/domain/habit/repository/HabitRepository.java
+++ b/src/main/java/com/swyp/server/domain/habit/repository/HabitRepository.java
@@ -16,6 +16,8 @@ import org.springframework.stereotype.Repository;
 public interface HabitRepository extends JpaRepository<Habit, Long> {
     Optional<Habit> findByIdAndUserId(Long habitId, Long userId);
 
+    Optional<Habit> findByIdAndUserIdAndStatus(Long habitId, Long userId, RewardStatus status);
+
     @EntityGraph(attributePaths = "user")
     @Query(
             "SELECT h FROM Habit h "

--- a/src/main/java/com/swyp/server/domain/habit/service/HabitScheduler.java
+++ b/src/main/java/com/swyp/server/domain/habit/service/HabitScheduler.java
@@ -28,9 +28,17 @@ public class HabitScheduler {
     @Transactional
     @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
     public void checkExpiredHabits() {
-        log.info("만료된 습관 체크 스케줄러 시작");
         LocalDateTime now = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
 
+        log.info("실패 습관 확인 스케줄러 시작");
+        habitRepository.updateHabitFailCount();
+        habitRepository.updateImmediateFailureHabits();
+        habitRepository.updateCumulativeFailureHabits();
+
+        log.info("습관 실패 횟수 초기화 스케줄러 시작");
+        habitRepository.resetFailCount(now);
+
+        log.info("만료된 습관 체크 스케줄러 시작");
         List<Habit> expiredHabits = habitRepository.findExpiredHabits(now);
 
         expiredHabits.stream()
@@ -57,11 +65,7 @@ public class HabitScheduler {
                         });
 
         habitRepository.updateExpiredHabitsStatus(now);
-    }
 
-    @Transactional
-    @Scheduled(cron = "0 1 0 * * *", zone = "Asia/Seoul")
-    public void resetDailyHabits() {
         log.info("매일 습관 완료 상태 초기화 스케줄러 시작");
         habitRepository.resetAllHabits();
     }

--- a/src/main/java/com/swyp/server/domain/habit/service/HabitService.java
+++ b/src/main/java/com/swyp/server/domain/habit/service/HabitService.java
@@ -230,9 +230,15 @@ public class HabitService {
     public void retryFailedHabit(Long userId, Long habitId) {
         Habit habit =
                 habitRepository
-                        .findByIdAndUserId(habitId, userId)
+                        .findByIdAndUserIdAndStatus(habitId, userId, RewardStatus.FAIL)
                         .orElseThrow(() -> new CustomException(ErrorCode.HABIT_NOT_FOUND));
-        habit.updateRewardStatus(RewardStatus.IN_PROGRESS);
+
+        User user =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        habit.retry(user);
     }
 
     @Transactional

--- a/src/main/java/com/swyp/server/domain/habit/service/HabitService.java
+++ b/src/main/java/com/swyp/server/domain/habit/service/HabitService.java
@@ -227,6 +227,15 @@ public class HabitService {
     }
 
     @Transactional
+    public void retryFailedHabit(Long userId, Long habitId) {
+        Habit habit =
+                habitRepository
+                        .findByIdAndUserId(habitId, userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.HABIT_NOT_FOUND));
+        habit.updateRewardStatus(RewardStatus.IN_PROGRESS);
+    }
+
+    @Transactional
     public void updateHabitRewardStatusToInProgress(
             Long userId, Long habitId, HabitRewardUpdateRequest request) {
         User user =

--- a/src/main/java/com/swyp/server/domain/habit/service/HabitService.java
+++ b/src/main/java/com/swyp/server/domain/habit/service/HabitService.java
@@ -139,9 +139,9 @@ public class HabitService {
             targetUserIds.addAll(childIds);
         }
 
-        if (targetUserIds.isEmpty()) return HabitRewardListResponse.empty();
-
         List<RewardStatus> searchStatuses = determineSearchStatuses(user.getUserType(), status);
+
+        if(targetUserIds.isEmpty() || searchStatuses.isEmpty()) return HabitRewardListResponse.empty();
 
         List<Habit> habits =
                 habitRepository.findAllByUserIdsAndStatusOptional(targetUserIds, searchStatuses);
@@ -340,8 +340,12 @@ public class HabitService {
     }
 
     private List<RewardStatus> determineSearchStatuses(UserType userType, RewardStatus status) {
+        if (status == RewardStatus.FAIL) {
+            return List.of();
+        }
+
         if (status == RewardStatus.ALL) {
-            return null;
+            return List.of(RewardStatus.REWARD_CHECKING, RewardStatus.IN_PROGRESS, RewardStatus.REWARD_WAITING, RewardStatus.COMPLETE);
         }
 
         if (userType == UserType.CHILD && status == RewardStatus.IN_PROGRESS) {

--- a/src/main/java/com/swyp/server/domain/habit/service/HabitService.java
+++ b/src/main/java/com/swyp/server/domain/habit/service/HabitService.java
@@ -112,6 +112,12 @@ public class HabitService {
     }
 
     @Transactional(readOnly = true)
+    public FailedHabitListResponse getFailedHabits(Long userId) {
+        List<Habit> habits = habitRepository.findAllFailedHabitsByUserId(userId);
+        return FailedHabitListResponse.from(habits);
+    }
+
+    @Transactional(readOnly = true)
     public HabitRewardListResponse getHabitRewards(Long userId, RewardStatus status) {
         User user =
                 userRepository

--- a/src/test/java/com/swyp/server/domain/habit/HabitRepositoryTest.java
+++ b/src/test/java/com/swyp/server/domain/habit/HabitRepositoryTest.java
@@ -11,6 +11,7 @@ import com.swyp.server.domain.user.repository.UserRepository;
 import com.swyp.server.global.config.JpaAuditingConfig;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
+import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
@@ -21,6 +22,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @DataJpaTest
@@ -32,7 +34,231 @@ public class HabitRepositoryTest {
 
     @Autowired private UserRepository userRepository;
 
+    @Autowired private JdbcTemplate jdbcTemplate;
+
     @PersistenceContext private EntityManager entityManager;
+
+    @Test
+    @DisplayName("매일 자정 보상 확인중, 진행중 상태이며 수행 기간이 '3일', '7일'외의 습관들은 당일 미실행 시 실패 횟수가 1 증가하여야 한다.")
+    void updateHabitFailCount() {
+
+        User user =
+                User.builder()
+                        .email("testEmail")
+                        .nickname("testNickname")
+                        .profileImageUrl("testProfile")
+                        .role(Role.USER)
+                        .build();
+
+        user.completeProfile("testNickname", UserType.CHILD, "testCode");
+        user.agreeToTerms();
+
+        userRepository.save(user);
+
+        // 진행중, 수행 기간 14일, 미완료 습관
+        Habit fourteenDaysNotCompletedHabit =
+                Habit.builder()
+                        .user(user)
+                        .title("testTitle")
+                        .duration(HabitDuration.FOURTEEN_DAYS)
+                        .reward("testReward")
+                        .build();
+
+        fourteenDaysNotCompletedHabit.updateRewardStatus(RewardStatus.IN_PROGRESS);
+
+        // 진행중, 수행 기간 14일, 완료 습관
+        Habit fourteenDaysCompleteHabit =
+                Habit.builder()
+                        .user(user)
+                        .title("testTitle")
+                        .duration(HabitDuration.FOURTEEN_DAYS)
+                        .reward("testReward")
+                        .build();
+
+        fourteenDaysCompleteHabit.complete();
+        fourteenDaysCompleteHabit.updateRewardStatus(RewardStatus.IN_PROGRESS);
+
+        // 진행중, 수행 기간 7일, 미완료 습관
+        Habit sevenDaysNotCompletedHabit =
+                Habit.builder()
+                        .user(user)
+                        .title("testTitle")
+                        .duration(HabitDuration.SEVEN_DAYS)
+                        .reward("testReward")
+                        .build();
+
+        sevenDaysNotCompletedHabit.updateRewardStatus(RewardStatus.IN_PROGRESS);
+
+        habitRepository.saveAll(
+                List.of(
+                        fourteenDaysNotCompletedHabit,
+                        fourteenDaysCompleteHabit,
+                        sevenDaysNotCompletedHabit));
+
+        habitRepository.updateHabitFailCount();
+
+        Habit fourteenDaysNotCompletedHabitInDB =
+                habitRepository.findById(fourteenDaysNotCompletedHabit.getId()).get();
+        Habit fourteenDaysCompletedHabitInDB =
+                habitRepository.findById(fourteenDaysCompleteHabit.getId()).get();
+        Habit sevenDaysNotCompletedHabitInDB =
+                habitRepository.findById(sevenDaysNotCompletedHabit.getId()).get();
+
+        Assertions.assertThat(fourteenDaysNotCompletedHabitInDB.getFailCount()).isEqualTo(1);
+        Assertions.assertThat(fourteenDaysCompletedHabitInDB.getFailCount()).isEqualTo(0);
+        Assertions.assertThat(sevenDaysNotCompletedHabitInDB.getFailCount()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("매일 자정 보상 확인중, 진행중 상태이며 수행 기간이 '3일', '7일'인 습관들은 당일 미실행 시 실패 상태가 되어야 한다.")
+    void updateImmediateFailureHabits() {
+        User user =
+                User.builder()
+                        .email("testEmail")
+                        .nickname("testNickname")
+                        .profileImageUrl("testProfile")
+                        .role(Role.USER)
+                        .build();
+
+        user.completeProfile("testNickname", UserType.CHILD, "testCode");
+        user.agreeToTerms();
+
+        userRepository.save(user);
+
+        Habit threeDaysNotCompletedHabit =
+                Habit.builder()
+                        .user(user)
+                        .title("testTitle")
+                        .duration(HabitDuration.THREE_DAYS)
+                        .reward("testReward")
+                        .build();
+
+        threeDaysNotCompletedHabit.updateRewardStatus(RewardStatus.IN_PROGRESS);
+
+        Habit sevenDaysNotCompletedHabit =
+                Habit.builder()
+                        .user(user)
+                        .title("testTitle")
+                        .duration(HabitDuration.SEVEN_DAYS)
+                        .reward("testReward")
+                        .build();
+
+        sevenDaysNotCompletedHabit.updateRewardStatus(RewardStatus.IN_PROGRESS);
+
+        habitRepository.saveAll(List.of(threeDaysNotCompletedHabit, sevenDaysNotCompletedHabit));
+
+        habitRepository.updateImmediateFailureHabits();
+
+        Habit threeDaysNotCompletedHabitInDB =
+                habitRepository.findById(threeDaysNotCompletedHabit.getId()).get();
+        Habit sevenDaysNotCompletedHabitInDB =
+                habitRepository.findById(sevenDaysNotCompletedHabit.getId()).get();
+
+        Assertions.assertThat(threeDaysNotCompletedHabitInDB.getStatus())
+                .isEqualTo(RewardStatus.FAIL);
+        Assertions.assertThat(sevenDaysNotCompletedHabitInDB.getStatus())
+                .isEqualTo(RewardStatus.FAIL);
+    }
+
+    @Test
+    @DisplayName("매일 자정 보상 확인중, 진행중 상태이며 수행 기간이 '3일', '7일' 외 습관들은 실패 횟수가 2회 이상이면 실패 상태가 되어야 한다.")
+    void updateCumulativeFailureHabits() {
+        User user =
+                User.builder()
+                        .email("testEmail")
+                        .nickname("testNickname")
+                        .profileImageUrl("testProfile")
+                        .role(Role.USER)
+                        .build();
+
+        user.completeProfile("testNickname", UserType.CHILD, "testCode");
+        user.agreeToTerms();
+
+        userRepository.save(user);
+
+        Habit fourteenDaysOneFailedHabit =
+                Habit.builder()
+                        .user(user)
+                        .title("testTitle")
+                        .duration(HabitDuration.FOURTEEN_DAYS)
+                        .reward("testReward")
+                        .build();
+
+        fourteenDaysOneFailedHabit.updateRewardStatus(RewardStatus.IN_PROGRESS);
+
+        Habit fourteenDaysTwoFailedHabit =
+                Habit.builder()
+                        .user(user)
+                        .title("testTitle")
+                        .duration(HabitDuration.FOURTEEN_DAYS)
+                        .reward("testReward")
+                        .build();
+
+        fourteenDaysTwoFailedHabit.updateRewardStatus(RewardStatus.IN_PROGRESS);
+
+        ReflectionTestUtils.setField(fourteenDaysOneFailedHabit, "failCount", 1);
+        ReflectionTestUtils.setField(fourteenDaysTwoFailedHabit, "failCount", 2);
+        habitRepository.saveAll(List.of(fourteenDaysOneFailedHabit, fourteenDaysTwoFailedHabit));
+
+        habitRepository.updateCumulativeFailureHabits();
+
+        Habit fourteenDaysOneFailedHabitInDB =
+                habitRepository.findById(fourteenDaysOneFailedHabit.getId()).get();
+        Habit fourteenDaysTwoFailedHabitInDB =
+                habitRepository.findById(fourteenDaysTwoFailedHabit.getId()).get();
+
+        Assertions.assertThat(fourteenDaysOneFailedHabitInDB.getStatus())
+                .isNotEqualTo(RewardStatus.FAIL);
+        Assertions.assertThat(fourteenDaysTwoFailedHabitInDB.getStatus())
+                .isEqualTo(RewardStatus.FAIL);
+    }
+
+    @Test
+    @DisplayName(
+            "매일 자정 보상 확인중, 진행중 상태이며 수행 기간이 '3일', '7일' 외이며 실패 횟수가 2회 미만인 습관은 습관 생성 날짜를 기준으로 10일에 한번씩 습관 실패 횟수가 초기화된다.")
+    void resetFailCount() {
+        User user =
+                User.builder()
+                        .email("testEmail")
+                        .nickname("testNickname")
+                        .profileImageUrl("testProfile")
+                        .role(Role.USER)
+                        .build();
+
+        user.completeProfile("testNickname", UserType.CHILD, "testCode");
+        user.agreeToTerms();
+
+        userRepository.save(user);
+
+        LocalDateTime now = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+        LocalDateTime nowMinusTenDays = now.minusDays(10);
+
+        Habit fourteenDaysOneFailedHabit =
+                Habit.builder()
+                        .user(user)
+                        .title("testTitle")
+                        .duration(HabitDuration.FOURTEEN_DAYS)
+                        .reward("testReward")
+                        .build();
+
+        fourteenDaysOneFailedHabit.updateRewardStatus(RewardStatus.IN_PROGRESS);
+
+        ReflectionTestUtils.setField(fourteenDaysOneFailedHabit, "failCount", 1);
+
+        habitRepository.save(fourteenDaysOneFailedHabit);
+
+        jdbcTemplate.update(
+                "UPDATE habits SET created_at = ? WHERE id = ?",
+                Timestamp.valueOf(nowMinusTenDays),
+                fourteenDaysOneFailedHabit.getId());
+
+        habitRepository.resetFailCount(now);
+
+        Habit fourteenDaysOneFailedHabitInDB =
+                habitRepository.findById(fourteenDaysOneFailedHabit.getId()).get();
+
+        Assertions.assertThat(fourteenDaysOneFailedHabitInDB.getFailCount()).isEqualTo(0);
+    }
 
     @Test
     @DisplayName("매일 자정 보상 확인중, 진행중 상태의 습관들은 완료 여부가 초기화되어야 한다.")
@@ -75,7 +301,6 @@ public class HabitRepositoryTest {
         habitRepository.saveAll(List.of(habit1, habit2));
 
         habitRepository.resetAllHabits();
-        entityManager.clear();
 
         Habit progressedHabit = habitRepository.findById(habit1.getId()).get();
         Habit completedHabit = habitRepository.findById(habit2.getId()).get();
@@ -141,7 +366,6 @@ public class HabitRepositoryTest {
         habitRepository.saveAll(List.of(childHabit, parentHabit));
 
         habitRepository.updateExpiredHabitsStatus(now);
-        entityManager.clear();
 
         Habit updateChild = habitRepository.findById(childHabit.getId()).get();
         Habit updateParent = habitRepository.findById(parentHabit.getId()).get();

--- a/src/test/java/com/swyp/server/domain/habit/HabitRepositoryTest.java
+++ b/src/test/java/com/swyp/server/domain/habit/HabitRepositoryTest.java
@@ -1,34 +1,36 @@
 package com.swyp.server.domain.habit;
 
+import com.swyp.server.domain.habit.dto.HabitRewardListResponse;
 import com.swyp.server.domain.habit.entity.Habit;
 import com.swyp.server.domain.habit.entity.HabitDuration;
 import com.swyp.server.domain.habit.entity.RewardStatus;
 import com.swyp.server.domain.habit.repository.HabitRepository;
+import com.swyp.server.domain.habit.service.HabitService;
 import com.swyp.server.domain.user.entity.Role;
 import com.swyp.server.domain.user.entity.User;
 import com.swyp.server.domain.user.entity.UserType;
 import com.swyp.server.domain.user.repository.UserRepository;
-import com.swyp.server.global.config.JpaAuditingConfig;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
-import java.sql.Timestamp;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.util.List;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Transactional;
 
-@DataJpaTest
-@Import(JpaAuditingConfig.class)
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+
+@SpringBootTest
+@Transactional
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class HabitRepositoryTest {
+
+    @Autowired private HabitService habitService;
 
     @Autowired private HabitRepository habitRepository;
 
@@ -36,7 +38,77 @@ public class HabitRepositoryTest {
 
     @Autowired private JdbcTemplate jdbcTemplate;
 
-    @PersistenceContext private EntityManager entityManager;
+    @Test
+    @DisplayName("status가 'FAIL'인 습관은 보상 조회 시 조회되지 않아야 한다.")
+    void getHabitRewards(){
+
+        User user =
+                User.builder()
+                        .email("testEmail")
+                        .nickname("testNickname")
+                        .profileImageUrl("testProfile")
+                        .role(Role.USER)
+                        .build();
+
+        user.completeProfile("testNickname", UserType.CHILD, "testCode");
+        user.agreeToTerms();
+
+        userRepository.save(user);
+
+        Habit habitInProgress =
+                Habit.builder()
+                        .user(user)
+                        .title("testTitle")
+                        .duration(HabitDuration.THREE_DAYS)
+                        .reward("testReward")
+                        .build();
+
+        habitInProgress.updateRewardStatus(RewardStatus.IN_PROGRESS);
+
+        Habit habitRewardWaiting =
+                Habit.builder()
+                        .user(user)
+                        .title("testTitle")
+                        .duration(HabitDuration.THREE_DAYS)
+                        .reward("testReward")
+                        .build();
+
+        habitRewardWaiting.updateRewardStatus(RewardStatus.REWARD_WAITING);
+
+        Habit habitCompleted =
+                Habit.builder()
+                        .user(user)
+                        .title("testTitle")
+                        .duration(HabitDuration.THREE_DAYS)
+                        .reward("testReward")
+                        .build();
+
+        habitCompleted.updateRewardStatus(RewardStatus.COMPLETE);
+
+        Habit habitFailed =
+                Habit.builder()
+                        .user(user)
+                        .title("testTitle")
+                        .duration(HabitDuration.THREE_DAYS)
+                        .reward("testReward")
+                        .build();
+
+        habitFailed.updateRewardStatus(RewardStatus.FAIL);
+
+
+        habitRepository.saveAll(List.of(habitInProgress, habitRewardWaiting, habitCompleted, habitFailed));
+
+        HabitRewardListResponse habitRewardsStatusAll = habitService.getHabitRewards(user.getId(), RewardStatus.ALL);
+        HabitRewardListResponse habitRewardsFail = habitService.getHabitRewards(user.getId(), RewardStatus.FAIL);
+
+        Assertions.assertThat(habitRewardsStatusAll.habitRewards())
+                .hasSize(3)
+                .extracting("status")
+                .doesNotContain(RewardStatus.FAIL)
+                .containsExactlyInAnyOrder(RewardStatus.IN_PROGRESS, RewardStatus.REWARD_WAITING, RewardStatus.COMPLETE);
+
+        Assertions.assertThat(habitRewardsFail.habitRewards()).isEmpty();
+    }
 
     @Test
     @DisplayName("매일 자정 보상 확인중, 진행중 상태이며 수행 기간이 '3일', '7일'외의 습관들은 당일 미실행 시 실패 횟수가 1 증가하여야 한다.")


### PR DESCRIPTION
## 📌 관련 이슈
- close #110 

## ✨ 변경 사항
- 재도전 습관 조회 및 삭제 기능 습관 재도전 기능 추가 
- 습관 실패 시에도 습관 상태 변경되도록 습관 스케줄러 기능 추가 

## 📸 테스트 증명 (필수)
<img width="365" height="126" alt="image" src="https://github.com/user-attachments/assets/673a254e-5f19-4bc7-9c1e-f10066db41a9" />


## 📚 리뷰어 참고 사항
- 14~99일짜리 습관은 기간 중 10일마다 하루는 습관을 체크하지 못해도 습관 기간이 지속된다는 정책을 해당 습관들은 10일마다 실패 횟수가 초기화 되는 식으로 구현을 하였는데, JPA의 JPQL 문법으론 구현이 어려워 nativeQuery를 사용하였습니다. 그래서 기존의 JPQL 문법을 사용하는 쿼리들은 Habit 엔티티를 대상으로 쿼리를 날리지만, 해당 쿼리는 habits DB 테이블을 향해 쿼리를 날리는 구조로 되어있어 기존 쿼리들과 형태가 약간 다릅니다.
- 습관 스케줄러 기능들을 시간별로 나누는 것이 크게 의미 없다고 판단되어 모두 00시에 동작되도록 스케줄러 코드를 변경하였습니다. 

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요?
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?
- [x] spotlessApply 실행했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * View a dedicated list of failed habits.
  * Retry a failed habit to return it to active progress.
  * Automatic failure tracking that marks habits as failed based on completion patterns and resets failure counters periodically.
* **Behavior Changes**
  * Failed habits are excluded from reward lookups and related reward displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->