### PR TITLE
[Feat/#114] 습관 재도전 시 습관 수행 기간 및 보상 수정 기능 추가

### DIFF
--- a/src/main/java/com/swyp/server/domain/habit/controller/HabitController.java
+++ b/src/main/java/com/swyp/server/domain/habit/controller/HabitController.java
@@ -76,8 +76,10 @@ public class HabitController {
     @Operation(summary = "습관 재도전")
     @PatchMapping("/failed/{habitId}/status/in-progress")
     public ResponseEntity<ApiResponse<Void>> retryFailedHabits(
-            @AuthenticationPrincipal Long userId, @PathVariable Long habitId) {
-        habitService.retryFailedHabit(userId, habitId);
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long habitId,
+            @Valid @RequestBody HabitRetryRequest request) {
+        habitService.retryFailedHabit(userId, habitId, request);
         return ResponseEntity.ok(ApiResponse.success(null));
     }
 

--- a/src/main/java/com/swyp/server/domain/habit/dto/HabitRetryRequest.java
+++ b/src/main/java/com/swyp/server/domain/habit/dto/HabitRetryRequest.java
@@ -1,0 +1,7 @@
+package com.swyp.server.domain.habit.dto;
+
+import com.swyp.server.domain.habit.entity.HabitDuration;
+import jakarta.validation.constraints.NotNull;
+
+public record HabitRetryRequest(
+        @NotNull(message = "HABIT_DURATION_REQUIRED") HabitDuration duration, String reward) {}

--- a/src/main/java/com/swyp/server/domain/habit/entity/Habit.java
+++ b/src/main/java/com/swyp/server/domain/habit/entity/Habit.java
@@ -92,14 +92,14 @@ public class Habit extends SoftDeletableEntity {
         this.status = rewardStatus;
     }
 
-    public void retry(User user, HabitRetryRequest request) {
+    public void retry(User user, HabitDuration duration, String reward) {
         if (user.getUserType() == UserType.CHILD) {
-            if (request.reward() == null || request.reward().isBlank())
+            if (reward == null || reward.isBlank())
                 throw new CustomException(ErrorCode.HABIT_REWARD_REQUIRED);
         }
 
-        this.duration = request.duration();
-        this.reward = request.reward();
+        this.duration = duration;
+        this.reward = reward;
         this.status =
                 user.getUserType() == UserType.CHILD
                         ? RewardStatus.REWARD_CHECKING

--- a/src/main/java/com/swyp/server/domain/habit/entity/Habit.java
+++ b/src/main/java/com/swyp/server/domain/habit/entity/Habit.java
@@ -1,6 +1,5 @@
 package com.swyp.server.domain.habit.entity;
 
-import com.swyp.server.domain.habit.dto.HabitRetryRequest;
 import com.swyp.server.domain.user.entity.User;
 import com.swyp.server.domain.user.entity.UserType;
 import com.swyp.server.global.SoftDeletableEntity;

--- a/src/main/java/com/swyp/server/domain/habit/entity/Habit.java
+++ b/src/main/java/com/swyp/server/domain/habit/entity/Habit.java
@@ -1,5 +1,6 @@
 package com.swyp.server.domain.habit.entity;
 
+import com.swyp.server.domain.habit.dto.HabitRetryRequest;
 import com.swyp.server.domain.user.entity.User;
 import com.swyp.server.domain.user.entity.UserType;
 import com.swyp.server.global.SoftDeletableEntity;
@@ -89,7 +90,9 @@ public class Habit extends SoftDeletableEntity {
         this.status = rewardStatus;
     }
 
-    public void retry(User user) {
+    public void retry(User user, HabitRetryRequest request) {
+        this.duration = request.duration();
+        this.reward = request.reward();
         this.status =
                 user.getUserType() == UserType.CHILD
                         ? RewardStatus.REWARD_CHECKING

--- a/src/main/java/com/swyp/server/domain/habit/entity/Habit.java
+++ b/src/main/java/com/swyp/server/domain/habit/entity/Habit.java
@@ -4,6 +4,8 @@ import com.swyp.server.domain.habit.dto.HabitRetryRequest;
 import com.swyp.server.domain.user.entity.User;
 import com.swyp.server.domain.user.entity.UserType;
 import com.swyp.server.global.SoftDeletableEntity;
+import com.swyp.server.global.exception.CustomException;
+import com.swyp.server.global.exception.ErrorCode;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -91,6 +93,11 @@ public class Habit extends SoftDeletableEntity {
     }
 
     public void retry(User user, HabitRetryRequest request) {
+        if (user.getUserType() == UserType.CHILD) {
+            if (request.reward() == null || request.reward().isBlank())
+                throw new CustomException(ErrorCode.HABIT_REWARD_REQUIRED);
+        }
+
         this.duration = request.duration();
         this.reward = request.reward();
         this.status =

--- a/src/main/java/com/swyp/server/domain/habit/repository/HabitRepository.java
+++ b/src/main/java/com/swyp/server/domain/habit/repository/HabitRepository.java
@@ -72,7 +72,7 @@ public interface HabitRepository extends JpaRepository<Habit, Long> {
 
     @Modifying(clearAutomatically = true)
     @Query(
-            "UPDATE Habit h SET h.status = 'FAIL' "
+            "UPDATE Habit h SET h.status = 'FAIL', h.isCompleted = false "
                     + " WHERE h.failCount > 1 "
                     + " AND h.status IN ('REWARD_CHECKING', 'IN_PROGRESS')"
                     + " AND h.duration NOT IN ('THREE_DAYS', 'SEVEN_DAYS')")

--- a/src/main/java/com/swyp/server/domain/habit/repository/HabitRepository.java
+++ b/src/main/java/com/swyp/server/domain/habit/repository/HabitRepository.java
@@ -64,7 +64,7 @@ public interface HabitRepository extends JpaRepository<Habit, Long> {
 
     @Modifying(clearAutomatically = true)
     @Query(
-            "UPDATE Habit h SET h.status = 'FAIL' "
+            "UPDATE Habit h SET h.status = 'FAIL', h.isCompleted = false "
                     + " WHERE h.isCompleted = false "
                     + " AND h.status IN ('REWARD_CHECKING', 'IN_PROGRESS')"
                     + " AND h.duration IN ('THREE_DAYS', 'SEVEN_DAYS')")

--- a/src/main/java/com/swyp/server/domain/habit/service/HabitService.java
+++ b/src/main/java/com/swyp/server/domain/habit/service/HabitService.java
@@ -141,7 +141,8 @@ public class HabitService {
 
         List<RewardStatus> searchStatuses = determineSearchStatuses(user.getUserType(), status);
 
-        if(targetUserIds.isEmpty() || searchStatuses.isEmpty()) return HabitRewardListResponse.empty();
+        if (targetUserIds.isEmpty() || searchStatuses.isEmpty())
+            return HabitRewardListResponse.empty();
 
         List<Habit> habits =
                 habitRepository.findAllByUserIdsAndStatusOptional(targetUserIds, searchStatuses);
@@ -227,7 +228,7 @@ public class HabitService {
     }
 
     @Transactional
-    public void retryFailedHabit(Long userId, Long habitId) {
+    public void retryFailedHabit(Long userId, Long habitId, HabitRetryRequest request) {
         Habit habit =
                 habitRepository
                         .findByIdAndUserIdAndStatus(habitId, userId, RewardStatus.FAIL)
@@ -238,7 +239,7 @@ public class HabitService {
                         .findById(userId)
                         .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        habit.retry(user);
+        habit.retry(user, request);
     }
 
     @Transactional
@@ -345,7 +346,11 @@ public class HabitService {
         }
 
         if (status == RewardStatus.ALL) {
-            return List.of(RewardStatus.REWARD_CHECKING, RewardStatus.IN_PROGRESS, RewardStatus.REWARD_WAITING, RewardStatus.COMPLETE);
+            return List.of(
+                    RewardStatus.REWARD_CHECKING,
+                    RewardStatus.IN_PROGRESS,
+                    RewardStatus.REWARD_WAITING,
+                    RewardStatus.COMPLETE);
         }
 
         if (userType == UserType.CHILD && status == RewardStatus.IN_PROGRESS) {

--- a/src/main/java/com/swyp/server/domain/habit/service/HabitService.java
+++ b/src/main/java/com/swyp/server/domain/habit/service/HabitService.java
@@ -239,7 +239,7 @@ public class HabitService {
                         .findById(userId)
                         .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        habit.retry(user, request);
+        habit.retry(user, request.duration(), request.reward());
     }
 
     @Transactional

--- a/src/test/java/com/swyp/server/domain/habit/HabitRepositoryTest.java
+++ b/src/test/java/com/swyp/server/domain/habit/HabitRepositoryTest.java
@@ -186,7 +186,8 @@ public class HabitRepositoryTest {
     }
 
     @Test
-    @DisplayName("매일 자정 보상 확인중, 진행중 상태이며 수행 기간이 '3일', '7일'인 습관들은 당일 미실행 시 실패 상태가 되어야 한다.")
+    @DisplayName(
+            "매일 자정 보상 확인중, 진행중 상태이며 수행 기간이 '3일', '7일'인 습관들은 당일 미실행 시 실패 상태가 되어야 하며 일일 성공 여부가 false가 되어야 한다.")
     void updateImmediateFailureHabits() {
         User user =
                 User.builder()
@@ -232,8 +233,11 @@ public class HabitRepositoryTest {
 
         Assertions.assertThat(threeDaysNotCompletedHabitInDB.getStatus())
                 .isEqualTo(RewardStatus.FAIL);
+        Assertions.assertThat(threeDaysNotCompletedHabitInDB.isCompleted()).isEqualTo(false);
+
         Assertions.assertThat(sevenDaysNotCompletedHabitInDB.getStatus())
                 .isEqualTo(RewardStatus.FAIL);
+        Assertions.assertThat(sevenDaysNotCompletedHabitInDB.isCompleted()).isEqualTo(false);
     }
 
     @Test

--- a/src/test/java/com/swyp/server/domain/habit/HabitRepositoryTest.java
+++ b/src/test/java/com/swyp/server/domain/habit/HabitRepositoryTest.java
@@ -10,6 +10,10 @@ import com.swyp.server.domain.user.entity.Role;
 import com.swyp.server.domain.user.entity.User;
 import com.swyp.server.domain.user.entity.UserType;
 import com.swyp.server.domain.user.repository.UserRepository;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,11 +23,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.sql.Timestamp;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.util.List;
 
 @SpringBootTest
 @Transactional
@@ -40,7 +39,7 @@ public class HabitRepositoryTest {
 
     @Test
     @DisplayName("status가 'FAIL'인 습관은 보상 조회 시 조회되지 않아야 한다.")
-    void getHabitRewards(){
+    void getHabitRewards() {
 
         User user =
                 User.builder()
@@ -95,17 +94,22 @@ public class HabitRepositoryTest {
 
         habitFailed.updateRewardStatus(RewardStatus.FAIL);
 
+        habitRepository.saveAll(
+                List.of(habitInProgress, habitRewardWaiting, habitCompleted, habitFailed));
 
-        habitRepository.saveAll(List.of(habitInProgress, habitRewardWaiting, habitCompleted, habitFailed));
-
-        HabitRewardListResponse habitRewardsStatusAll = habitService.getHabitRewards(user.getId(), RewardStatus.ALL);
-        HabitRewardListResponse habitRewardsFail = habitService.getHabitRewards(user.getId(), RewardStatus.FAIL);
+        HabitRewardListResponse habitRewardsStatusAll =
+                habitService.getHabitRewards(user.getId(), RewardStatus.ALL);
+        HabitRewardListResponse habitRewardsFail =
+                habitService.getHabitRewards(user.getId(), RewardStatus.FAIL);
 
         Assertions.assertThat(habitRewardsStatusAll.habitRewards())
                 .hasSize(3)
                 .extracting("status")
                 .doesNotContain(RewardStatus.FAIL)
-                .containsExactlyInAnyOrder(RewardStatus.IN_PROGRESS, RewardStatus.REWARD_WAITING, RewardStatus.COMPLETE);
+                .containsExactlyInAnyOrder(
+                        RewardStatus.IN_PROGRESS,
+                        RewardStatus.REWARD_WAITING,
+                        RewardStatus.COMPLETE);
 
         Assertions.assertThat(habitRewardsFail.habitRewards()).isEmpty();
     }
@@ -233,7 +237,8 @@ public class HabitRepositoryTest {
     }
 
     @Test
-    @DisplayName("매일 자정 보상 확인중, 진행중 상태이며 수행 기간이 '3일', '7일' 외 습관들은 실패 횟수가 2회 이상이면 실패 상태가 되어야 한다.")
+    @DisplayName(
+            "매일 자정 보상 확인중, 진행중 상태이며 수행 기간이 '3일', '7일' 외 습관들은 실패 횟수가 2회 이상이면 실패 상태가 되어야 하며 일일 성공 여부가 false가 되어야 한다.")
     void updateCumulativeFailureHabits() {
         User user =
                 User.builder()
@@ -281,8 +286,10 @@ public class HabitRepositoryTest {
 
         Assertions.assertThat(fourteenDaysOneFailedHabitInDB.getStatus())
                 .isNotEqualTo(RewardStatus.FAIL);
+
         Assertions.assertThat(fourteenDaysTwoFailedHabitInDB.getStatus())
                 .isEqualTo(RewardStatus.FAIL);
+        Assertions.assertThat(fourteenDaysTwoFailedHabitInDB.isCompleted()).isEqualTo(false);
     }
 
     @Test


### PR DESCRIPTION
## 📌 관련 이슈
- close #114 

## ✨ 변경 사항
- 습관 재도전 시 습관 수행 기간 및 보상을 수정 기능을 추가함

## 📸 테스트 증명 (필수)
로컬에서 빌드 완료

## 📚 리뷰어 참고 사항
- 해당 기능을 구현하며 수행기간이 3일 7일 외 습관에 대한 습관 실패 스케줄러 코드에서 습관의 일일 성공 여부도 수정되어야 할 거 같아 해당 부분도 수정하였습니다. 
- 추후 확장성이나 유지보수를 생각해보니 습관 재도전 시 보상 검증 로직을 Habit 엔티티 내부에 두는게 좋을 거 같아 Habit 엔티티의 retry() (습관 재도전) 로직 안에 두었습니다.  

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요?
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?
- [x] spotlessApply 실행했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Habit retry endpoint now accepts and validates duration and reward parameters, enabling more flexible retry operations.

* **Bug Fixes**
  * Failed habits are now properly marked as incomplete, ensuring accurate habit status tracking and preventing data inconsistencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->